### PR TITLE
3178 faraday migrate ats feeds remove httparty

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,8 +60,6 @@ gem "govuk_design_system_formbuilder", "~> 6.4.0"
 gem "groupdate"
 # guidance pages
 gem "high_voltage"
-# HTTP client for downloading GIAS data
-gem "httparty"
 # needed for processing of message attachments
 gem "image_processing"
 # startard library for creating IPAddresses. Used in production config

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1042,7 +1042,6 @@ DEPENDENCIES
   guard-shell
   guard-slim_lint
   high_voltage
-  httparty
   image_processing
   ipaddr
   jbuilder

--- a/app/services/vacancies/import/sources/broadbean.rb
+++ b/app/services/vacancies/import/sources/broadbean.rb
@@ -180,6 +180,6 @@ class Vacancies::Import::Sources::Broadbean
   end
 
   def feed
-    @feed ||= Nokogiri::XML(HTTParty.get(FEED_URL).body)
+    @feed ||= Nokogiri::XML(HttpClient.connection.get(FEED_URL).body)
   end
 end

--- a/app/services/vacancies/import/sources/fusion.rb
+++ b/app/services/vacancies/import/sources/fusion.rb
@@ -173,8 +173,8 @@ class Vacancies::Import::Sources::Fusion
   end
 
   def results
-    response = HTTParty.get(FEED_URL)
-    raise HTTParty::ResponseError, error_message unless response.success?
+    response = HttpClient.connection.get(FEED_URL)
+    raise FusionImportError, error_message unless response.success?
 
     JSON.parse(response.body)
   end

--- a/app/services/vacancies/import/sources/vacancy_poster.rb
+++ b/app/services/vacancies/import/sources/vacancy_poster.rb
@@ -173,6 +173,6 @@ class Vacancies::Import::Sources::VacancyPoster
   end
 
   def feed
-    @feed ||= Nokogiri::XML(HTTParty.get(FEED_URL).body)
+    @feed ||= Nokogiri::XML(HttpClient.connection.get(FEED_URL).body)
   end
 end

--- a/app/services/vacancies/import/sources/ventrus.rb
+++ b/app/services/vacancies/import/sources/ventrus.rb
@@ -172,6 +172,6 @@ class Vacancies::Import::Sources::Ventrus
   end
 
   def feed
-    @feed ||= Nokogiri::XML(HTTParty.get(FEED_URL).body)
+    @feed ||= Nokogiri::XML(HttpClient.connection.get(FEED_URL).body)
   end
 end

--- a/spec/services/vacancies/import/sources/broadbean_spec.rb
+++ b/spec/services/vacancies/import/sources/broadbean_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe Vacancies::Import::Sources::Broadbean do
   let(:response_body) { file_fixture("vacancy_sources/broadbean.xml").read }
-  let(:response) { double("BroadbeanHttpResponse", success?: true, body: response_body) }
 
   let!(:school1) { create(:school, name: "Test School", urn: "111111", phase: :primary, created_at: 1.week.ago) }
   let!(:out_of_scope_school) { create(:school, name: "Out of scope", urn: "999999", detailed_school_type: "Other independent school") }
@@ -30,7 +29,7 @@ RSpec.describe Vacancies::Import::Sources::Broadbean do
     end
 
     before do
-      expect(HTTParty).to receive(:get).with("http://example.com/feed.xml").and_return(response)
+      stub_request(:get, "http://example.com/feed.xml").to_return(body: response_body)
     end
 
     it "has the correct number of vacancies" do

--- a/spec/services/vacancies/import/sources/fusion_spec.rb
+++ b/spec/services/vacancies/import/sources/fusion_spec.rb
@@ -6,12 +6,11 @@ RSpec.describe Vacancies::Import::Sources::Fusion do
   let(:trust_schools) { [school1] }
 
   let(:response_body) { file_fixture("vacancy_sources/fusion.json").read }
-  let(:response) { double("FusionHttpResponse", success?: true, body: response_body) }
-  let(:argument_error_response) { double("FusionHttpResponse", success?: true, body: file_fixture("vacancy_sources/fusion_argument_error.json").read) }
+  let(:argument_error_body) { file_fixture("vacancy_sources/fusion_argument_error.json").read }
 
   describe "enumeration" do
     before do
-      expect(HTTParty).to receive(:get).with("http://example.com/feed.json").and_return(response)
+      stub_request(:get, "http://example.com/feed.json").to_return(body: response_body)
     end
 
     let(:vacancy) { subject.first }
@@ -562,7 +561,7 @@ RSpec.describe Vacancies::Import::Sources::Fusion do
 
   describe "enumeration error" do
     before do
-      expect(HTTParty).to receive(:get).with("http://example.com/feed.json").and_return(argument_error_response)
+      stub_request(:get, "http://example.com/feed.json").to_return(body: argument_error_body)
     end
 
     let(:vacancy) { subject.first }
@@ -571,6 +570,16 @@ RSpec.describe Vacancies::Import::Sources::Fusion do
       it "adds an error to the vacancy object" do
         expect(vacancy.errors.count).to eq(1)
       end
+    end
+  end
+
+  describe "when the feed request is unsuccessful" do
+    before do
+      stub_request(:get, "http://example.com/feed.json").to_return(status: 500)
+    end
+
+    it "raises a FusionImportError" do
+      expect { subject.to_a }.to raise_error(described_class::FusionImportError, "Something went wrong with Fusion Import")
     end
   end
 end

--- a/spec/services/vacancies/import/sources/vacancy_poster_spec.rb
+++ b/spec/services/vacancies/import/sources/vacancy_poster_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe Vacancies::Import::Sources::VacancyPoster do
   let(:response_body) { file_fixture("vacancy_sources/vacancy_poster.xml").read }
-  let(:response) { instance_double(Net::HTTPResponse, body: response_body) }
 
   let!(:school1) { create(:school, name: "Test School", urn: "123456", phase: :primary) }
   let(:schools) { [school1] }
@@ -26,7 +25,7 @@ RSpec.describe Vacancies::Import::Sources::VacancyPoster do
     end
 
     before do
-      expect(HTTParty).to receive(:get).with("http://example.com/feed.xml").and_return(response)
+      stub_request(:get, "http://example.com/feed.xml").to_return(body: response_body)
     end
 
     it "has the correct number of vacancies" do

--- a/spec/services/vacancies/import/sources/ventrus_spec.rb
+++ b/spec/services/vacancies/import/sources/ventrus_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe Vacancies::Import::Sources::Ventrus do
   let(:response_body) { file_fixture("vacancy_sources/ventrus.xml").read }
-  let(:response) { double("VentrusHttpResponse", success?: true, body: response_body) }
 
   let!(:school1) { create(:school, name: "Test School", urn: "111111", phase: :primary) }
   let!(:school_group) { create(:school_group, name: "Ventrus", uid: "4243", schools: schools) }
@@ -28,7 +27,7 @@ RSpec.describe Vacancies::Import::Sources::Ventrus do
     end
 
     before do
-      expect(HTTParty).to receive(:get).with("http://example.com/feed.xml").and_return(response)
+      stub_request(:get, "http://example.com/feed.xml").to_return(body: response_body)
     end
 
     it "has the correct number of vacancies" do


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/OjuPRGNR/3178-replace-httparty-with-faraday-gem

## Changes in this PR:

Remove httpparty 
PR 5/5
## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
