### PR TITLE
pin simplecov due to defect

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -206,7 +206,7 @@ group :test do
   gem "rspec-rebound"
   gem "selenium-webdriver"
   gem "shoulda-matchers"
-  gem "simplecov", require: false
+  gem "simplecov", "< 1.1", require: false # 1.1.0 and 1.1.1 seem to have a bug in generating HTML coverage reports
   gem "site_prism"
   gem "uri-query_params"
   gem "vcr"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -821,7 +821,7 @@ GEM
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
-    simplecov (1.1.1)
+    simplecov (1.0.3)
     simplecov_json_formatter (0.1.4)
     site_prism (6.0.1)
       addressable (~> 2.8, >= 2.8.4)
@@ -1108,7 +1108,7 @@ DEPENDENCIES
   sentry-rails
   sentry-ruby
   shoulda-matchers
-  simplecov
+  simplecov (< 1.1)
   site_prism
   skylight
   slim-rails
@@ -1433,7 +1433,7 @@ CHECKSUMS
   shellany (0.0.1) sha256=0e127a9132698766d7e752e82cdac8250b6adbd09e6c0a7fbbb6f61964fedee7
   shoulda-matchers (8.0.1) sha256=5dbb46e5765b9da225111b085e0819e8c8a121ff94bba430a153eb1ea2c60288
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
-  simplecov (1.1.1) sha256=25825ef13f0b2e74694d769817dad6ab8e90131dabdaa666e522fea105521e78
+  simplecov (1.0.3) sha256=38ef0514f16ae7562f0d0f4df02610071115103d301b6de7dacbcc000082e39b
   simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
   site_prism (6.0.1) sha256=f8144d8baa8d533787436c0f777dd95ac6a17b4f9743d10e3141c418b6bd5843
   site_prism-all_there (3.0.9) sha256=3d9e0b722fa62a3553589130dea23fa50c99dc80f108c851d7480d341d83f4f6


### PR DESCRIPTION
## Changes in this PR:

Pin simplecov due to bug in version 1.1 generating HTML coverage reports.

Re-generate rubocop-todo as it was over nearly 4 months old