### PR TITLE
2855 - Debugging review app reconcile

### DIFF
--- a/.github/workflows/debug_delete_review_app.yml
+++ b/.github/workflows/debug_delete_review_app.yml
@@ -1,0 +1,147 @@
+name: Delete review app
+
+on:
+  pull_request:
+    types: [closed, unlabeled]
+    paths-ignore:
+      - "bigquery/**"
+      - "documentation/**"
+      - "terraform/common/**"
+      - "**.md"
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull Request number to delete (EG: 1234 for review-pr-1234)"
+        required: true
+  workflow_call:
+    inputs:
+      pr_number:
+        description: "Pull Request number to delete (EG: 1234 for review-pr-1234)"
+        required: true
+        type: string
+
+# Wait until the Build And Deploy for the same PR is finished before starting this workflow.
+# If triggered by a manual workflow dispatch with a PR number, builds the corresponding 'ref' to match the Build and Deploy
+# concurrency group for that PR.
+# For a closed or unlabeled PR, the 'ref' is available and matches the Build and deploy one.
+# When the ref resolves to 'refs/heads/main' (somehow it happens sometimes), we want to allow concurrent runs, so we append
+# the run ID to make it unique.
+concurrency: workflow-Build-and-deploy-${{ (github.event_name == 'workflow_dispatch' && format('refs/pull/{0}/merge', github.event.inputs.pr_number)) || (github.event.pull_request && format('refs/pull/{0}/merge', github.event.pull_request.number)) || (github.ref != 'refs/heads/main' && github.ref) || format('skip-main-{0}', github.run_id) }}
+
+permissions:
+  id-token: write
+  pull-requests: write
+
+env:
+  DOCKER_REPOSITORY: ghcr.io/dfe-digital/teaching-vacancies
+
+jobs:
+  delete-review-app:
+    # Check if PR was closed with deploy label OR workflow was manually triggered OR deploy label was removed
+    # Define conditions for triggering the job
+    # 1. PR is closed and has the 'deploy' label
+    # 2. Workflow is manually triggered
+    # 3. Workflow is called by another workflow
+    # 4. 'deploy' label is removed from the PR
+    # if: >
+    #   (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'deploy')) ||
+    #   github.event_name == 'workflow_dispatch' ||
+    #   github.event_name == 'workflow_call' ||
+    #   (github.event.action == 'unlabeled' && github.event.label.name == 'deploy')
+    name: Delete review app
+    runs-on: ubuntu-latest
+    environment: review
+
+    steps:
+      - name: Debug trigger
+        run: |
+          echo "event_name=${{ github.event_name }}"
+          echo "action=${{ github.event.action }}"
+          echo "pr_number=${{ inputs.pr_number }}"
+
+      - name: Set environment variables
+        run: |
+          PR_NUMBER="${{ inputs.pr_number }}"
+
+          if [ -z "$PR_NUMBER" ]; then
+            PR_NUMBER="${{ github.event.inputs.pr_number || github.event.number }}"
+          fi
+          ENVIRONMENT=review-pr-${PR_NUMBER}
+          echo "PR_NUMBER=${PR_NUMBER}" >> $GITHUB_ENV
+          echo "ENVIRONMENT=${ENVIRONMENT}" >> $GITHUB_ENV
+          echo "LINK_TO_RUN=https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" >> $GITHUB_ENV
+          echo "LINK_TO_PR=https://github.com/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}" >> $GITHUB_ENV
+          echo "LINK_TO_APP=https://teaching-vacancies-${ENVIRONMENT}.test.teacherservices.cloud" >> $GITHUB_ENV
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6.2.3
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+          role-to-assume: Deployments
+          role-duration-seconds: 3600
+          role-skip-session-tagging: true
+
+      - uses: actions/checkout@v7.0.1
+        name: Checkout Code
+
+      - uses: google-github-actions/auth@v3
+        with:
+          project_id: teacher-vacancy-service
+          workload_identity_provider: projects/689616473831/locations/global/workloadIdentityPools/teaching-vacancies/providers/teaching-vacancies
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1.321.0
+
+      - name: Download fetch_config.rb
+        shell: bash
+        run: |
+          echo "::group:: Download fetch_config.rb script"
+          curl -s https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/master/scripts/fetch_config/fetch_config.rb -o bin/fetch_config.rb
+          chmod +x bin/fetch_config.rb
+          echo "::endgroup::"
+
+      - name: Validate secrets
+        shell: bash
+        run: |
+          gem install aws-sdk-ssm --no-document
+          bin/fetch_config.rb -s aws-ssm-parameter-path:/teaching-vacancies/dev/app -d quiet \
+            && echo Data in /teaching-vacancies/dev looks valid
+
+      - name: Terraform pin version
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: 1.14.5
+
+      - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
+        with:
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+
+      - name: Terraform destroy
+        run: echo "Would delete PR ${PR_NUMBER}"
+          echo "env.PR_NUMBER=${{env.PR_NUMBER}}"
+      #     make review ci terraform-app-destroy pr_id=${{env.PR_NUMBER}}
+
+      # - name: Delete Terraform Statefile
+      #   run: ./bin/delete-state-file ${{env.PR_NUMBER}}
+
+      # - name: Post sticky pull request comment
+      #   uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # Pinned at v3.0.5
+      #   with:
+      #     message: |
+      #       Review app <${{ env.LINK_TO_APP }}> was successfully deleted
+
+      # - name: Send failure message to twd_tv_dev channel
+      #   if: failure()
+      #   uses: DFE-Digital/github-actions/send-to-teams-channel@master
+      #   with:
+      #     teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
+      #     title: Delete review app failure
+      #     service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}
+      #     message: |
+      #       Failed deletion of review app PR ${{env.PR_NUMBER}}
+      #       Pull Requst: ${{ env.LINK_TO_PR }}
+      #       Review app: ${{ env.LINK_TO_APP }}

--- a/.github/workflows/review-app-reconcile.yml
+++ b/.github/workflows/review-app-reconcile.yml
@@ -10,7 +10,7 @@ on:
         type: boolean
 
   schedule:
-    - cron: "0 08 * * 0"
+    - cron: "*/30 * * * *"
 
 permissions:
   id-token: write
@@ -166,7 +166,7 @@ jobs:
       matrix:
         pr_number: ${{ fromJson(needs.find-stale-review-apps.outputs.stale_prs) }}
 
-    uses: ./.github/workflows/delete_review_app.yml
+    uses: ./.github/workflows/debug_delete_review_app.yml
 
     with:
       pr_number: ${{ matrix.pr_number }}


### PR DESCRIPTION
## Trello card URL

[Link](https://trello.com/c/ZWznDc8Y/2855-add-review-app-cleanup-workflow)

## Changes in this PR:

A simple change to add a debugging delete workflow that just outputs the event type that calls the workflow, along with PR number of review app it would have deleted, without any deletions taking place.
Also updates the schedule cron to every 30 minutes so that we can see the details during the day.

This is due to the fact that the deletion process is continually skipped for this service, even though the review apps are found.

## Guidance to review

There is no true way to test this as we need to determine how it is being called when scheduled (hence the change to the schedule cron).
However, I have proved that no review apps will be deleted during this time by running it against the **test branch** and setting `dry_run` to `false` here:

[Test branch: dry_run==false](https://github.com/DFE-Digital/teaching-vacancies/actions/runs/32943639119/job/98099645552)

I then ran it against **main** with `dry_run` set to `true` here:

[main branch: dry_run==true](https://github.com/DFE-Digital/teaching-vacancies/actions/runs/32944133593)

This shows that no review apps were deleted during the testing process.

## Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Applied DevOps label
- [x] Tested by running locally