### PR TITLE
Track application link clicks

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -38,6 +38,14 @@ class VacanciesController < ApplicationController
   end
   # rubocop:enable Metrics/AbcSize
 
+  def apply
+    vacancy = PublishedVacancy.live.friendly.find(params[:id])
+    raise ActiveRecord::RecordNotFound if vacancy.application_link.blank?
+
+    Vacancy.increment_counter(:external_application_clicks, vacancy.id)
+    redirect_to vacancy.application_link, allow_other_host: true
+  end
+
   def campaign_landing_page
     @campaign_page = CampaignPage[params[:utm_content]]
     campaign_params = CampaignSearchParamsMerger.new(campaign_search_params, @campaign_page).merged_params

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -42,7 +42,7 @@ class VacanciesController < ApplicationController
     vacancy = PublishedVacancy.live.friendly.find(params[:id])
     raise ActiveRecord::RecordNotFound if vacancy.application_link.blank?
 
-    Vacancy.increment_counter(:external_application_clicks, vacancy.id)
+    vacancy.increment!(:external_application_clicks)
     redirect_to vacancy.application_link, allow_other_host: true
   end
 

--- a/app/helpers/links_helper.rb
+++ b/app/helpers/links_helper.rb
@@ -81,7 +81,7 @@ module LinksHelper
   def apply_link(vacancy, **)
     tracked_open_in_new_tab_button_link_to(
       t("jobs.view_advert.#{school_or_college_type(vacancy.organisation)}"),
-      vacancy.application_link,
+      apply_job_path(vacancy),
       "aria-label": t("jobs.aria_labels.apply_link"),
       link_type: :get_more_information,
       link_subject: vacancy.id,

--- a/app/models/vacancy_template.rb
+++ b/app/models/vacancy_template.rb
@@ -30,6 +30,7 @@ class VacancyTemplate < ApplicationRecord
     external_source
     external_reference
     external_advert_url
+    external_application_clicks
     start_date_type
     earliest_start_date
     latest_start_date

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -542,6 +542,7 @@ shared:
     - job_address_county
     - job_address_postcode
     - fe_role_qts_required
+    - external_application_clicks
   failed_imported_vacancies:
     - id
     - import_errors

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -93,6 +93,29 @@
       "note": ""
     },
     {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "42ada4273ecac39e5a82c397387ce17fba49366e31977c50aba4d8114ecc4da9",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/vacancies_controller.rb",
+      "line": 46,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(PublishedVacancy.live.friendly.find(params[:id]).application_link, :allow_other_host => true)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "VacanciesController",
+        "method": "apply"
+      },
+      "user_input": "PublishedVacancy.live.friendly.find(params[:id]).application_link",
+      "confidence": "Weak",
+      "cwe_id": [
+        601
+      ],
+      "note": "The destination is a stored application URL and redirecting to the external recruitment site is the intended behaviour."
+    },
+    {
       "warning_type": "Unscoped Find",
       "warning_code": 82,
       "fingerprint": "4555c296b942cffb89636f6e393403f7c6a8918d34ce290871cd44ee9a0a6ab1",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -353,6 +353,7 @@ Rails.application.routes.draw do
   post "/cookies-preferences", to: "cookies_preferences#create", as: "create_cookies_preferences"
 
   resources :jobs, only: %i[index show], controller: "vacancies" do
+    get :apply, on: :member
     resources :documents, only: %i[show]
     member do
       get :trn_interstitial

--- a/db/migrate/20260824135752_add_external_application_clicks_to_vacancies.rb
+++ b/db/migrate/20260824135752_add_external_application_clicks_to_vacancies.rb
@@ -1,0 +1,5 @@
+class AddExternalApplicationClicksToVacancies < ActiveRecord::Migration[8.1]
+  def change
+    add_column :vacancies, :external_application_clicks, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_18_075048) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_24_135752) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "citext"
@@ -983,6 +983,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_18_075048) do
     t.datetime "expires_at", precision: nil
     t.integer "extension_reason"
     t.string "external_advert_url"
+    t.integer "external_application_clicks", default: 0, null: false
     t.string "external_reference"
     t.string "external_source"
     t.boolean "fe_role_qts_required"

--- a/spec/jobs/import_from_vacancy_source_job_spec.rb
+++ b/spec/jobs/import_from_vacancy_source_job_spec.rb
@@ -126,6 +126,7 @@ RSpec.describe ImportFromVacancySourceJob do
           "expired_vacancy_feedback_email_sent_at" => nil,
           "expires_at" => "2023-06-06T09:00:00.000+01:00",
           "external_advert_url" => "https://example.com/jobs/123",
+          "external_application_clicks" => 0,
           "external_reference" => "invalid_vac_ref",
           "external_source" => "may_the_feed_be_with_you",
           "fixed_term_contract_duration" => "",

--- a/spec/models/vacancy_template_spec.rb
+++ b/spec/models/vacancy_template_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe VacancyTemplate do
                            publisher_organisation_id
                            readable_job_location
                            external_advert_url
+                           external_application_clicks
                            external_reference
                            external_source
                            geolocation

--- a/spec/requests/vacancies_spec.rb
+++ b/spec/requests/vacancies_spec.rb
@@ -49,4 +49,33 @@ RSpec.describe "Vacancies" do
       end
     end
   end
+
+  describe "GET #apply" do
+    let(:vacancy) { create(:vacancy, :apply_via_website, external_application_clicks: 2) }
+
+    it "increments the application click count and redirects to the application website" do
+      expect { get apply_job_path(vacancy) }
+        .to change { vacancy.reload.external_application_clicks }.from(2).to(3)
+
+      expect(response).to redirect_to(vacancy.application_link)
+    end
+
+    it "does not count clicks for an expired vacancy" do
+      vacancy.update!(expires_at: 1.day.ago)
+
+      expect { get apply_job_path(vacancy) }
+        .to(not_change { vacancy.reload.external_application_clicks })
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "does not count clicks when there is no application link" do
+      vacancy.update!(application_link: nil)
+
+      expect { get apply_job_path(vacancy) }
+        .to(not_change { vacancy.reload.external_application_clicks })
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
 end

--- a/spec/system/jobseekers/jobseekers_can_complete_a_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_complete_a_job_application_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe "Jobseekers can complete a job application" do
       let(:ab_test) { "apply" }
 
       it "allows the user to apply" do
-        expect(page).to have_link(href: vacancy.application_link)
+        expect(page).to have_link(href: apply_job_path(vacancy))
       end
     end
 

--- a/spec/views/vacancies/show.html.slim_spec.rb
+++ b/spec/views/vacancies/show.html.slim_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "vacancies/show" do
       end
 
       it "has an application link" do
-        expect(rendered).to have_link I18n.t("jobs.view_advert.school"), href: vacancy.application_link
+        expect(rendered).to have_link I18n.t("jobs.view_advert.school"), href: apply_job_path(vacancy)
       end
     end
   end


### PR DESCRIPTION
## Trello card URL

Part of https://trello.com/c/vqKrPa54/3137-spike-we-want-a-mechanism-to-count-hard-to-fill-roles-so-we-can-show-them-to-jobseekers

## Changes in this PR:
This ticket adds a new field to track the number of jobseekers that click an apply link which takes them to a school or college's own application form.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
