### PR TITLE
Bump OpenSSL to 3.5.8-r0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # These are packages we need over-and-beyond the base image
 ARG EXTRA_PACKAGES="imagemagick libpng libjpeg libxml2 libxslt tzdata shared-mime-info vips-poppler vips-magick proj-dev libpq postgresql18 openexr=3.4.13-r0"
 # These are security patches to the base image
-ARG PROD_PACKAGES="openssl=3.5.7-r0 sqlite-libs=3.53.4-r0"
+ARG PROD_PACKAGES="openssl=3.5.8-r0 sqlite-libs=3.53.4-r0"
 
 FROM ruby:4.0.2-alpine3.23 AS builder
 


### PR DESCRIPTION
## Trello card URL

## Changes in this PR:

[Snyk reporting an issue](https://github.com/DFE-Digital/teaching-vacancies/actions/runs/32947099424/job/98110216499?pr=9209) with openssl so bumping to new version

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
