### PR TITLE
2855 - Updated regex to remove worker suffix

### DIFF
--- a/.github/workflows/review-app-reconcile.yml
+++ b/.github/workflows/review-app-reconcile.yml
@@ -85,11 +85,11 @@ jobs:
             kubectl get deployments -n tv-development -o json |
             jq -r '
               .items[]
-              | select(.metadata.name | test("^teaching-vacancies-review-pr-[0-9]+-worker$"))
+              | select(.metadata.name | test("^teaching-vacancies-review-pr-[0-9]+"))
               | .metadata.name
             ' |
-            sed -n 's/^teaching-vacancies-review-pr-\([0-9]\+\)-worker$/\1/p' |
-            sort -n
+            sed -n 's/^teaching-vacancies-review-pr-\([0-9]\+\).*$/\1/p' |
+            sort -nu
           )
 
           if [[ -z "$prs" ]]; then


### PR DESCRIPTION
## Trello card URL

[Link](https://trello.com/c/ZWznDc8Y/2855-add-review-app-cleanup-workflow)

## Changes in this PR:

A very small regex change, based on a conversation with Richard McVelia regarding the various naming conventions for review apps.

No longer specifically looks for the `-worker` suffix.

## Guidance to review

I have completed a dry run against this branch [here](https://github.com/DFE-Digital/teaching-vacancies/actions/runs/32958251997/job/98144648117).

As you may see, it has found several extra stale review apps, compared to the previous iteration - a dry run for which is [here](https://github.com/DFE-Digital/teaching-vacancies/actions/runs/32954869758).

## Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Applied DevOps label
- [x] Tested by running locally