### PR TITLE
Add use my current location on homepage

### DIFF
--- a/app/assets/javascript/js_components/locationFinder/locationFinder.js
+++ b/app/assets/javascript/js_components/locationFinder/locationFinder.js
@@ -26,6 +26,14 @@ const LocationFinder = class extends Controller {
     this.input.addEventListener('focus', () => {
       this.removeErrorMessage();
     });
+
+    if (this.input.value === '' && navigator.permissions) {
+      navigator.permissions.query({ name: 'geolocation' }).then((result) => {
+        if (result.state === 'granted') {
+          this.findLocation();
+        }
+      });
+    }
   }
 
   findLocation() {

--- a/app/assets/javascript/js_components/locationFinder/locationFinder.js
+++ b/app/assets/javascript/js_components/locationFinder/locationFinder.js
@@ -27,12 +27,8 @@ const LocationFinder = class extends Controller {
       this.removeErrorMessage();
     });
 
-    if (this.input.value === '' && navigator.permissions) {
-      navigator.permissions.query({ name: 'geolocation' }).then((result) => {
-        if (result.state === 'granted') {
-          this.findLocation();
-        }
-      });
+    if (this.input.value === '' && navigator.geolocation) {
+      this.findLocation();
     }
   }
 
@@ -46,6 +42,9 @@ const LocationFinder = class extends Controller {
         this.onFailure();
         logger.log(`${LOGGING_MESSAGE}: ${error.message}`);
       });
+    }, () => {
+      this.onFailure();
+      logger.log(LOGGING_MESSAGE);
     });
   }
 

--- a/app/assets/javascript/js_components/locationFinder/locationFinder.js
+++ b/app/assets/javascript/js_components/locationFinder/locationFinder.js
@@ -27,7 +27,7 @@ const LocationFinder = class extends Controller {
       this.removeErrorMessage();
     });
 
-    if (this.input.value === '' && navigator.geolocation) {
+    if (this.input.value === '' && navigator.geolocation && this.element.offsetParent !== null) {
       this.findLocation();
     }
   }

--- a/app/assets/javascript/js_components/locationFinder/locationFinder.js
+++ b/app/assets/javascript/js_components/locationFinder/locationFinder.js
@@ -27,9 +27,23 @@ const LocationFinder = class extends Controller {
       this.removeErrorMessage();
     });
 
-    if (this.input.value === '' && navigator.geolocation && this.element.offsetParent !== null) {
-      this.findLocation();
+    this.autoFindLocationIfPermitted();
+  }
+
+  autoFindLocationIfPermitted() {
+    if (this.input.value !== '' || !navigator.geolocation || this.element.offsetParent === null) {
+      return;
     }
+
+    if (!navigator.permissions || !navigator.permissions.query) {
+      return;
+    }
+
+    navigator.permissions.query({ name: 'geolocation' }).then((status) => {
+      if (status.state === 'granted') {
+        this.findLocation();
+      }
+    }).catch(() => {});
   }
 
   findLocation() {

--- a/app/assets/javascript/js_components/locationFinder/locationFinder.test.js
+++ b/app/assets/javascript/js_components/locationFinder/locationFinder.test.js
@@ -94,3 +94,70 @@ describe('when coordinates are not available from browser geolocation API', () =
     expect(document.getElementById('location-finder__error')).toBe(null);
   });
 });
+
+describe('automatically finding the location', () => {
+  beforeEach(() => {
+    controller = application.getControllerForElementAndIdentifier(document.querySelector('[data-controller="location-finder"]'), 'location-finder');
+    controller.input.value = '';
+    global.navigator.geolocation = currentPosition({
+      coords: {
+        latitude: 51.1,
+        longitude: 45.3,
+      },
+    });
+    Object.defineProperty(controller.element, 'offsetParent', {
+      configurable: true,
+      value: controller.element.parentElement,
+    });
+  });
+
+  afterEach(() => {
+    delete global.navigator.permissions;
+    jest.restoreAllMocks();
+  });
+
+  it('finds the location when permission has already been granted', async () => {
+    global.navigator.permissions = {
+      query: jest.fn().mockResolvedValue({ state: 'granted' }),
+    };
+    const findLocation = jest.spyOn(controller, 'findLocation').mockImplementation();
+
+    controller.autoFindLocationIfPermitted();
+    await Promise.resolve();
+
+    expect(global.navigator.permissions.query).toHaveBeenCalledWith({ name: 'geolocation' });
+    expect(findLocation).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['prompt', 'denied'])('does not find the location when permission is %s', async (state) => {
+    global.navigator.permissions = {
+      query: jest.fn().mockResolvedValue({ state }),
+    };
+    const findLocation = jest.spyOn(controller, 'findLocation').mockImplementation();
+
+    controller.autoFindLocationIfPermitted();
+    await Promise.resolve();
+
+    expect(findLocation).not.toHaveBeenCalled();
+  });
+
+  it('does not find the location when the permissions API is unavailable', () => {
+    const findLocation = jest.spyOn(controller, 'findLocation').mockImplementation();
+
+    controller.autoFindLocationIfPermitted();
+
+    expect(findLocation).not.toHaveBeenCalled();
+  });
+
+  it('does not find the location when checking permission fails', async () => {
+    global.navigator.permissions = {
+      query: jest.fn().mockRejectedValue(new Error('Unable to check permission')),
+    };
+    const findLocation = jest.spyOn(controller, 'findLocation').mockImplementation();
+
+    controller.autoFindLocationIfPermitted();
+    await Promise.resolve();
+
+    expect(findLocation).not.toHaveBeenCalled();
+  });
+});

--- a/app/views/colleges/_form.html.slim
+++ b/app/views/colleges/_form.html.slim
@@ -6,6 +6,7 @@
     = f.govuk_text_field :location,
       label: { text: t("organisations.search.location"), size: "s" },
       class: %w[location-finder__input]
+  = render "vacancies/search/current_location", target: "college-search-form-location-field"
 
   = f.govuk_collection_select :radius, radius_filter_options, :last, :first,
     label: { text: t("jobs.search.within_radius"), size: "s" },

--- a/app/views/home/_search.html.slim
+++ b/app/views/home/_search.html.slim
@@ -5,6 +5,7 @@
     .search__form
       = render "vacancies/search/keyword", f: f
       = render "vacancies/search/location", f: f, label_text: t(".location_label"), show_hint: false, desktop: true
+      = render "vacancies/search/current_location", target: "location-field"
       = f.govuk_submit t("buttons.search"), class: "govuk-button--start govuk-button--inverse"
 
   h2.govuk-heading-s = t("jobs.search.popular_searches.title")

--- a/app/views/organisations/search/_form.html.slim
+++ b/app/views/organisations/search/_form.html.slim
@@ -6,6 +6,7 @@
     = f.govuk_text_field :location,
       label: { text: t("organisations.search.location"), size: "s" },
       class: %w[location-finder__input]
+  = render "vacancies/search/current_location", target: "location-field"
 
   = f.govuk_collection_select :radius, radius_filter_options, :last, :first,
     label: { text: t("jobs.search.within_radius"), size: "s" },

--- a/spec/system/jobseekers/jobseekers_can_search_from_home_page_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_search_from_home_page_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe "Searching on the home page" do
     visit root_path
   end
 
+  scenario "shows the use my location button" do
+    expect(page).to have_css(".location-finder")
+  end
+
   context "when the location is not a polygon" do
     scenario "resets radius to a default radius" do
       fill_in I18n.t("jobs.search.keyword"), with: "math"

--- a/spec/system/jobseekers/jobseekers_can_search_from_home_page_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_search_from_home_page_spec.rb
@@ -5,10 +5,6 @@ RSpec.describe "Searching on the home page" do
     visit root_path
   end
 
-  scenario "shows the use my location button" do
-    expect(page).to have_css(".location-finder")
-  end
-
   context "when the location is not a polygon" do
     scenario "resets radius to a default radius" do
       fill_in I18n.t("jobs.search.keyword"), with: "math"

--- a/spec/views/home/index.html.slim_spec.rb
+++ b/spec/views/home/index.html.slim_spec.rb
@@ -41,6 +41,10 @@ RSpec.describe "home/index" do
     let(:jobseeker) { nil }
     let(:publisher) { nil }
 
+    it "renders the use my location button" do
+      expect(rendered).to have_css(".location-finder")
+    end
+
     it "renders the correct links" do
       expect(rendered).to have_content(I18n.t("buttons.sign_in"))
       expect(rendered).to have_content(I18n.t("buttons.search"))


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/xJF4hBXF/3108-spike-search-based-on-users-location-from-the-browser

## Changes in this PR:

This PR adds a "Use my current location" link on the homepage/shool search page/colleges page when the user views it on mobile. We actually already have similar links on the jobs search page and the job alerts page.

It also autopopulates the location field on these pages when a user is using mobile/tablet and they have given us permission to use their location.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
