### PR TITLE
filter and job alerts for college support roles

### DIFF
--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -30,8 +30,7 @@ module VacanciesHelper
   end
 
   def fe_college_support_job_roles_options
-    roles = (Vacancy::SUPPORT_JOB_ROLES - %w[other_support]) + Vacancy::FE_SUPPORT_JOB_ROLES + %w[other_support]
-    roles.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_role_form.fe_support_job_role_options.#{option}")] }
+    Vacancy::SUPPORT_JOB_ROLES.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_role_form.support_job_role_options.#{option}")] }
   end
 
   def teaching_job_roles_options
@@ -39,7 +38,7 @@ module VacanciesHelper
   end
 
   def support_job_roles_options
-    Vacancy::SUPPORT_JOB_ROLES.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_role_form.support_job_role_options.#{option}")] }
+    Vacancy::SCHOOL_SUPPORT_JOB_ROLES.map { |option| [option, I18n.t("helpers.label.publishers_job_listing_job_role_form.support_job_role_options.#{option}")] }
   end
 
   def vacancy_tag(state)

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -33,14 +33,18 @@ class Vacancy < ApplicationRecord
 
   TEACHING_JOB_ROLES = %w[teacher head_of_year_or_phase head_of_department_or_curriculum assistant_headteacher
                           deputy_headteacher headteacher sendco other_leadership].freeze
-  SUPPORT_JOB_ROLES = %w[teaching_assistant higher_level_teaching_assistant education_support
-                         administration_hr_data_and_finance catering_cleaning_and_site_management
-                         it_support pastoral_health_and_welfare other_support].freeze
+
+  # Only here so that 'other_support' is in the correct location when used for display purposes in 'SUPPORT_JOB_ROLES' constant
+  SCHOOL_SUPPORT_ROLES = %w[teaching_assistant higher_level_teaching_assistant education_support
+                            administration_hr_data_and_finance catering_cleaning_and_site_management
+                            it_support pastoral_health_and_welfare].freeze
+  SCHOOL_SUPPORT_JOB_ROLES = SCHOOL_SUPPORT_ROLES + %w[other_support]
 
   # Only offered to publishers posting on behalf of an FE college - see Vacancy#for_an_fe_college?
   FE_SUPPORT_JOB_ROLES = %w[leadership_and_management business_support_administration_and_corporate_services
                             student_support_learning_and_progress marketing_and_communications
                             apprenticeships_and_commercial_services].freeze
+  SUPPORT_JOB_ROLES = SCHOOL_SUPPORT_ROLES + FE_SUPPORT_JOB_ROLES + %w[other_support]
 
   SCHOOL_PHASES_MATCHING_VACANCY_PHASES = %w[nursery primary secondary sixth_form_or_college].freeze
 

--- a/config/locales/forms.yml
+++ b/config/locales/forms.yml
@@ -581,15 +581,6 @@ en:
           catering_cleaning_and_site_management: Catering, cleaning and site management
           it_support: IT support
           pastoral_health_and_welfare: Pastoral, health and welfare
-          other_support: Other support role
-        fe_support_job_role_options:
-          teaching_assistant: Teaching assistant
-          higher_level_teaching_assistant: HLTA (higher level teaching assistant)
-          education_support: Learning support or cover supervisor
-          administration_hr_data_and_finance: Administration, HR, data and finance
-          catering_cleaning_and_site_management: Catering, cleaning and site management
-          it_support: IT support
-          pastoral_health_and_welfare: Pastoral, health and welfare
           leadership_and_management: Leadership and management
           business_support_administration_and_corporate_services: Business support, administration and corporate services
           student_support_learning_and_progress: Student support, learning and progress

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -140,7 +140,7 @@ FactoryBot.define do
     end
 
     trait :for_seed_data do
-      job_roles { [factory_sample(Vacancy.job_roles.keys)] }
+      job_roles { factory_rand_sample(Vacancy.job_roles.keys, 2..4) }
       ect_status { factory_sample(Vacancy.ect_statuses.keys) if job_roles.include?("teacher") }
       is_job_share { [true, false].sample }
       visa_sponsorship_available { [true, false].sample }

--- a/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_college_spec.rb
+++ b/spec/system/publishers/publishers_can_publish_a_vacancy_as_a_college_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe "Creating a vacancy as an FE college" do
     # Job role page shows Teacher for teaching roles, and the full support role list (school-style plus FE-specific), but not other teaching roles
     expect(publisher_job_role_page).to be_displayed
     expect(page).to have_content(I18n.t("helpers.label.publishers_job_listing_job_role_form.teaching_job_role_options.teacher"))
-    expect(page).to have_content(I18n.t("helpers.label.publishers_job_listing_job_role_form.fe_support_job_role_options.leadership_and_management"))
-    expect(page).to have_content(I18n.t("helpers.label.publishers_job_listing_job_role_form.fe_support_job_role_options.teaching_assistant"))
+    expect(page).to have_content(I18n.t("helpers.label.publishers_job_listing_job_role_form.support_job_role_options.leadership_and_management"))
+    expect(page).to have_content(I18n.t("helpers.label.publishers_job_listing_job_role_form.support_job_role_options.teaching_assistant"))
     expect(page).to have_no_content(I18n.t("helpers.label.publishers_job_listing_job_role_form.teaching_job_role_options.headteacher"))
     publisher_job_role_page.fill_in_and_submit_form(vacancy.job_roles.first)
 


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/3UdGVUdR/3206-support-roles-for-fe-ability-to-search-filter-and-the-job-alerts-for-job-seekers

## Changes in this PR:

Add FE support roles to Job Alerts and Filters

## Screenshots of UI changes:

### Before

### After
<img width="574" height="641" alt="SupportAlerts" src="https://github.com/user-attachments/assets/ae264a09-a8b4-49d0-b649-3dce9eaf798d" />
<img width="349" height="856" alt="SupportFilters" src="https://github.com/user-attachments/assets/694966f0-5200-4d31-831f-256f98506632" />




