### PR TITLE
Vacancy validations

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -130,6 +130,7 @@ PUBLISHER_VACANCY_MAPPINGS = {
   references_and_self_disclosure: %w[can_manage_self_disclosure],
   relist: %w[],
   statistics: %w[can_view_vacancy_statistics],
+  vacancy_review_sections: %w[],
   wizard_base: %w[],
   wizard: %w[],
 }.freeze

--- a/app/models/concerns/resettable.rb
+++ b/app/models/concerns/resettable.rb
@@ -8,8 +8,6 @@ module Resettable
   end
 
   def reset_dependent_fields
-    reset_actual_salary
-    reset_fixed_term_contract_duration
     reset_keystages
     reset_subjects
     set_default_key_stage
@@ -22,18 +20,6 @@ module Resettable
     reset_contact_number
     reset_further_details
     reset_benefits_details
-  end
-
-  def reset_actual_salary
-    return unless working_patterns_changed? && working_patterns == ["full_time"]
-
-    self.actual_salary = ""
-  end
-
-  def reset_fixed_term_contract_duration
-    return unless contract_type_changed? && contract_type != "fixed_term"
-
-    self.fixed_term_contract_duration = ""
   end
 
   def reset_keystages

--- a/app/models/concerns/resettable.rb
+++ b/app/models/concerns/resettable.rb
@@ -12,14 +12,8 @@ module Resettable
     reset_subjects
     set_default_key_stage
     reset_ect_status
-    reset_receive_applications
-    reset_application_email
     reset_application_form
-    reset_application_link
     reset_documents
-    reset_contact_number
-    reset_further_details
-    reset_benefits_details
   end
 
   def reset_keystages
@@ -40,51 +34,15 @@ module Resettable
     self.ect_status = nil
   end
 
-  def reset_receive_applications
-    return unless enable_job_applications_changed? && enable_job_applications
-
-    self.receive_applications = nil
-  end
-
-  def reset_application_email
-    return unless receive_applications_changed? && receive_applications != "email"
-
-    self.application_email = nil
-  end
-
   def reset_application_form
     return unless enable_job_applications_changed? || receive_applications_changed?
 
     application_form.purge_later if enable_job_applications || receive_applications == "website"
   end
 
-  def reset_application_link
-    return unless receive_applications_changed? && receive_applications != "website"
-
-    self.application_link = nil
-  end
-
   def reset_documents
     return unless include_additional_documents_changed?
 
     supporting_documents.each(&:purge_later) unless include_additional_documents?
-  end
-
-  def reset_contact_number
-    return unless contact_number_provided_changed? && !contact_number_provided
-
-    self.contact_number = nil
-  end
-
-  def reset_further_details
-    return unless further_details_provided_changed? && !further_details_provided
-
-    self.further_details = nil
-  end
-
-  def reset_benefits_details
-    return unless benefits_changed? && !benefits
-
-    self.benefits_details = nil
   end
 end

--- a/app/models/vacancy_template.rb
+++ b/app/models/vacancy_template.rb
@@ -55,8 +55,6 @@ class VacancyTemplate < ApplicationRecord
 
   validates :name, presence: true
 
-  validates :key_stages, absence: true, unless: -> { allow_key_stages? }
-
   array_enum job_roles: Vacancy::JOB_ROLES
   enum :ect_status, Vacancy::ECT_STATUSES
   enum :contract_type, Vacancy::CONTRACT_TYPES

--- a/app/models/vacancy_template.rb
+++ b/app/models/vacancy_template.rb
@@ -55,6 +55,8 @@ class VacancyTemplate < ApplicationRecord
 
   validates :name, presence: true
 
+  validates :key_stages, absence: true, unless: -> { allow_key_stages? }
+
   array_enum job_roles: Vacancy::JOB_ROLES
   enum :ect_status, Vacancy::ECT_STATUSES
   enum :contract_type, Vacancy::CONTRACT_TYPES

--- a/app/presenters/vacancy_decorator.rb
+++ b/app/presenters/vacancy_decorator.rb
@@ -94,15 +94,7 @@ class VacancyDecorator < Draper::Decorator
   def fixed_term_contract_duration
     model.fixed_term_contract_duration if model.contract_type == "fixed_term"
   end
-  #
-  # def key_stages
-  #   model.allow_key_stages? ? model.key_stages : []
-  # end
-  #
-  # def subjects
-  #   model.allow_subjects? ? model.subjects : []
-  # end
-  #
+
   def receive_applications
     model.receive_applications unless model.enable_job_applications?
   end

--- a/app/presenters/vacancy_decorator.rb
+++ b/app/presenters/vacancy_decorator.rb
@@ -89,7 +89,7 @@ class VacancyDecorator < Draper::Decorator
     model.working_patterns == %w[full_time] ? "" : model.actual_salary
   end
 
-  delegate :key_stages, :subjects, :receive_applications, :contact_number, :application_email, :further_details, :application_link
+  delegate :key_stages, :subjects
 
   def fixed_term_contract_duration
     model.fixed_term_contract_duration if model.contract_type == "fixed_term"
@@ -103,25 +103,25 @@ class VacancyDecorator < Draper::Decorator
   #   model.allow_subjects? ? model.subjects : []
   # end
   #
-  # def receive_applications
-  #   model.receive_applications unless model.enable_job_applications?
-  # end
-  #
-  # def contact_number
-  #   model.contact_number if model.contact_number_provided
-  # end
-  #
-  # def application_email
-  #   model.application_email if model.email?
-  # end
-  #
-  # def further_details
-  #   model.further_details if model.further_details_provided?
-  # end
-  #
-  # def application_link
-  #   model.application_link if model.website?
-  # end
+  def receive_applications
+    model.receive_applications unless model.enable_job_applications?
+  end
+
+  def contact_number
+    model.contact_number if model.contact_number_provided
+  end
+
+  def application_email
+    model.application_email if model.email?
+  end
+
+  def further_details
+    model.further_details if model.further_details_provided?
+  end
+
+  def application_link
+    model.application_link if model.website?
+  end
 
   private
 

--- a/app/presenters/vacancy_decorator.rb
+++ b/app/presenters/vacancy_decorator.rb
@@ -4,24 +4,24 @@ class VacancyDecorator < Draper::Decorator
   delegate :school_group_names, :job_title, :organisation_name, :organisation, :organisations,
            :is_job_share, :id, :school_group_types,
            :publish_on, :skills_and_experience, :job_roles,
-           :hourly_rate?, :hourly_rate, :salary?, :actual_salary?, :pay_scale?, :salary, :pay_scale, :actual_salary,
+           :hourly_rate?, :hourly_rate, :salary?, :pay_scale?, :salary, :pay_scale,
            :about_school, :expires_at, :expired?, :enable_job_applications?,
-           :for_an_fe_college?, :live?, :uploaded_form?, :ect_suitable?,
-           :slug, :allow_key_stages?, :allow_subjects?, :contract_type, :ect_status,
-           :visa_sponsorship_available, :fixed_term_contract_duration, :school_offer, :flexi_working,
-           :further_details, :include_additional_documents, :central_office?, :contact_email, :contact_number,
-           :school_visits?, :location, :key_stages, :subjects, :benefits?, :supporting_documents,
-           :application_link, :allow_phase_to_be_set?, :published?, :draft?, :pending?,
+           :for_an_fe_college?, :live?, :uploaded_form?,
+           :slug, :allow_key_stages?, :allow_subjects?, :contract_type,
+           :visa_sponsorship_available, :school_offer, :flexi_working,
+           :include_additional_documents, :central_office?, :contact_email,
+           :school_visits?, :location, :benefits?, :supporting_documents,
+           :allow_phase_to_be_set?, :published?, :draft?, :pending?,
            :salary_types, :benefits,
            :working_patterns_details?, :working_patterns_details,
-           :completed_steps, :phases, :further_details_provided, :school_visits, :contact_number_provided, :contact_number_provided?,
-           :receive_applications, :allow_job_applications?, :can_receive_job_applications?, :enable_job_applications,
-           :catholic?, :religious_character, :other_religion?, :anonymise_applications?, :is_parental_leave_cover, :email?,
-           :application_form, :application_email, :website?, :vacancy_address,
+           :completed_steps, :phases, :further_details_provided, :school_visits,
+           :allow_job_applications?, :can_receive_job_applications?, :enable_job_applications,
+           :catholic?, :religious_character, :other_religion?, :anonymise_applications?, :is_parental_leave_cover,
+           :application_form, :website?, :vacancy_address,
            :external?, :job_advert, :external_advert_url,
            :supporting_documents_in_order,
            :other_start_date_details, :earliest_start_date, :latest_start_date, :starts_on, :start_date_type,
-           :teaching_or_middle_leader_role?
+           :teaching_or_middle_leader_role?, :email?, :ect_suitable?, :ect_status
 
   include ActionView::Helpers::TextHelper
 
@@ -29,7 +29,7 @@ class VacancyDecorator < Draper::Decorator
 
   # simplecov:disable
   def benefits_details
-    simple_format(fix_bullet_points(model.benefits_details)) if model.benefits_details.present?
+    simple_format(fix_bullet_points(model.benefits_details)) if model.benefits?
   end
   # simplecov:enable
 
@@ -84,6 +84,44 @@ class VacancyDecorator < Draper::Decorator
   def fe_role_qts_required
     I18n.t("helpers.label.publishers_job_listing_about_the_role_form.fe_role_qts_required_options.#{model.fe_role_qts_required}")
   end
+
+  def actual_salary
+    model.working_patterns == %w[full_time] ? "" : model.actual_salary
+  end
+
+  delegate :key_stages, :subjects, :receive_applications, :contact_number, :application_email, :further_details, :application_link
+
+  def fixed_term_contract_duration
+    model.fixed_term_contract_duration if model.contract_type == "fixed_term"
+  end
+  #
+  # def key_stages
+  #   model.allow_key_stages? ? model.key_stages : []
+  # end
+  #
+  # def subjects
+  #   model.allow_subjects? ? model.subjects : []
+  # end
+  #
+  # def receive_applications
+  #   model.receive_applications unless model.enable_job_applications?
+  # end
+  #
+  # def contact_number
+  #   model.contact_number if model.contact_number_provided
+  # end
+  #
+  # def application_email
+  #   model.application_email if model.email?
+  # end
+  #
+  # def further_details
+  #   model.further_details if model.further_details_provided?
+  # end
+  #
+  # def application_link
+  #   model.application_link if model.website?
+  # end
 
   private
 

--- a/app/views/publishers/vacancies/vacancy_review_sections/_application_process.html.slim
+++ b/app/views/publishers/vacancies/vacancy_review_sections/_application_process.html.slim
@@ -88,12 +88,12 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
                     href: organisation_job_build_path(vacancy.id, :contact_details),
                     visually_hidden_text: t("jobs.contact_email")
 
-  - unless vacancy.contact_number_provided.nil?
+  - unless vacancy.contact_number.nil?
     - summary_list.with_row(html_attributes: { id: "contact_number_provided" }) do |row|
       - row.with_key
         = t("jobs.contact_number_provided")
       - row.with_value
-        = vacancy.contact_number_provided? || vacancy.contact_number.present? ? "Yes" : "No"
+        = vacancy.contact_number.present? ? "Yes" : "No"
       - row.with_action text: t("buttons.change"),
                   href: organisation_job_build_path(vacancy.id, :contact_details, "back_to_#{action_name}": "true"),
                   visually_hidden_text: t("jobs.contact_number_provided")

--- a/app/views/publishers/vacancies/vacancy_review_sections/_job_details.html.slim
+++ b/app/views/publishers/vacancies/vacancy_review_sections/_job_details.html.slim
@@ -124,7 +124,7 @@ h2 class="govuk-heading-m govuk-!-margin-bottom-4"
             li
               div => "#{t('jobs.annual_salary')}:"
               = vacancy.salary
-          - if vacancy.actual_salary?
+          - if vacancy.actual_salary.present?
             li
               div => "#{t('jobs.actual_salary')}:"
               = vacancy.actual_salary

--- a/app/views/vacancies/listing/_job_details.html.slim
+++ b/app/views/vacancies/listing/_job_details.html.slim
@@ -41,7 +41,7 @@ section#job-details class="govuk-!-margin-bottom-5"
           h3.govuk-heading-s class="govuk-!-margin-bottom-0" = t("jobs.annual_salary")
         - row.with_value text: vacancy.salary
 
-    - if vacancy.actual_salary?
+    - if vacancy.actual_salary.present?
       - summary_list.with_row do |row|
         - row.with_key do
           h3.govuk-heading-s class="govuk-!-margin-bottom-0" = t("jobs.actual_salary")

--- a/spec/concerns/resettable_spec.rb
+++ b/spec/concerns/resettable_spec.rb
@@ -7,18 +7,18 @@ RSpec.describe Resettable do
     it { expect(vacancy).to respond_to(:reset_dependent_fields) }
   end
 
-  # context "when changing education support" do
-  #   subject(:update_education_support) { vacancy.update(job_roles: %w[education_support]) }
-  #
-  #   let(:vacancy) { build(:vacancy, phases: %w[primary], job_roles: %w[teacher], key_stages: %w[ks1]) }
-  #   let(:previous_key_stages) { vacancy.key_stages }
-  #
-  #   it "resets key stages" do
-  #     expect { update_education_support }
-  #       .to change(vacancy, :key_stages)
-  #       .from(previous_key_stages).to([])
-  #   end
-  # end
+  context "when changing education support" do
+    subject(:update_education_support) { vacancy.update(job_roles: %w[education_support]) }
+
+    let(:vacancy) { build(:vacancy, phases: %w[primary], job_roles: %w[teacher], key_stages: %w[ks1]) }
+    let(:previous_key_stages) { vacancy.key_stages }
+
+    it "resets key stages" do
+      expect { update_education_support }
+        .to change(vacancy, :key_stages)
+        .from(previous_key_stages).to([])
+    end
+  end
 
   context "when changing education phases" do
     subject(:update_education_phases) { vacancy.update(phases: updated_phases) }
@@ -37,15 +37,15 @@ RSpec.describe Resettable do
       end
     end
 
-    # context "to nursery" do
-    #   let(:updated_phases) { %w[nursery] }
-    #
-    #   it "resets key stages" do
-    #     expect { update_education_phases }
-    #       .to change(vacancy, :key_stages)
-    #       .from(previous_key_stages).to(%w[early_years])
-    #   end
-    # end
+    context "to nursery" do
+      let(:updated_phases) { %w[nursery] }
+
+      it "resets key stages" do
+        expect { update_education_phases }
+          .to change(vacancy, :key_stages)
+          .from(previous_key_stages).to(%w[early_years])
+      end
+    end
   end
 
   context "when changing job role" do

--- a/spec/concerns/resettable_spec.rb
+++ b/spec/concerns/resettable_spec.rb
@@ -7,48 +7,18 @@ RSpec.describe Resettable do
     it { expect(vacancy).to respond_to(:reset_dependent_fields) }
   end
 
-  context "when changing working patterns" do
-    subject(:update_working_patterns) { vacancy.update(working_patterns: %w[full_time]) }
-
-    let(:vacancy) { build(:vacancy, working_patterns: %w[part_time]) }
-    let(:previous_actual_salary) { vacancy.actual_salary }
-
-    it "resets actual salary" do
-      expect { update_working_patterns }
-        .to change(vacancy, :actual_salary)
-        .from(previous_actual_salary).to("")
-    end
-  end
-
-  context "when changing contract type" do
-    subject(:update_contract_type) { vacancy.update(contract_type: "permanent") }
-
-    let(:vacancy) { build(:vacancy, contract_type: contract_type) }
-    let(:previous_fixed_term_contract_duration) { vacancy.fixed_term_contract_duration }
-
-    context "from fixed term" do
-      let(:contract_type) { "fixed_term" }
-
-      it "resets fixed term contract duration" do
-        expect { update_contract_type }
-          .to change(vacancy, :fixed_term_contract_duration)
-          .from(previous_fixed_term_contract_duration).to("")
-      end
-    end
-  end
-
-  context "when changing education support" do
-    subject(:update_education_support) { vacancy.update(job_roles: %w[education_support]) }
-
-    let(:vacancy) { build(:vacancy, phases: %w[primary], job_roles: %w[teacher], key_stages: %w[ks1]) }
-    let(:previous_key_stages) { vacancy.key_stages }
-
-    it "resets key stages" do
-      expect { update_education_support }
-        .to change(vacancy, :key_stages)
-        .from(previous_key_stages).to([])
-    end
-  end
+  # context "when changing education support" do
+  #   subject(:update_education_support) { vacancy.update(job_roles: %w[education_support]) }
+  #
+  #   let(:vacancy) { build(:vacancy, phases: %w[primary], job_roles: %w[teacher], key_stages: %w[ks1]) }
+  #   let(:previous_key_stages) { vacancy.key_stages }
+  #
+  #   it "resets key stages" do
+  #     expect { update_education_support }
+  #       .to change(vacancy, :key_stages)
+  #       .from(previous_key_stages).to([])
+  #   end
+  # end
 
   context "when changing education phases" do
     subject(:update_education_phases) { vacancy.update(phases: updated_phases) }
@@ -67,15 +37,15 @@ RSpec.describe Resettable do
       end
     end
 
-    context "to nursery" do
-      let(:updated_phases) { %w[nursery] }
-
-      it "resets key stages" do
-        expect { update_education_phases }
-          .to change(vacancy, :key_stages)
-          .from(previous_key_stages).to(%w[early_years])
-      end
-    end
+    # context "to nursery" do
+    #   let(:updated_phases) { %w[nursery] }
+    #
+    #   it "resets key stages" do
+    #     expect { update_education_phases }
+    #       .to change(vacancy, :key_stages)
+    #       .from(previous_key_stages).to(%w[early_years])
+    #   end
+    # end
   end
 
   context "when changing job role" do

--- a/spec/concerns/resettable_spec.rb
+++ b/spec/concerns/resettable_spec.rb
@@ -61,46 +61,6 @@ RSpec.describe Resettable do
     end
   end
 
-  context "when changing enable job applications" do
-    let(:vacancy) do
-      create(:draft_vacancy, :apply_via_website)
-    end
-
-    it "resets receive application" do
-      expect { vacancy.update!(enable_job_applications: true) }
-        .to change { vacancy.reload.receive_applications }
-        .from("website").to(nil)
-    end
-  end
-
-  context "when changing receive application" do
-    subject(:update_receive_application) { vacancy.update!(receive_applications: new_receive_applications, application_link: Faker::Internet.url) }
-
-    context "from email to website" do
-      let(:vacancy) { build(:vacancy, enable_job_applications: false, receive_applications: "email", application_email: Faker::Internet.email(domain: TEST_EMAIL_DOMAIN)) }
-      let(:new_receive_applications) { "website" }
-      let(:previous_application_email) { vacancy.application_email }
-
-      it "resets application email" do
-        expect { update_receive_application }
-        .to change(vacancy, :application_email)
-        .from(previous_application_email).to(nil)
-      end
-    end
-
-    context "from website to email" do
-      let(:vacancy) { build(:vacancy, enable_job_applications: false, receive_applications: "website", application_link: "www.test.com") }
-      let(:new_receive_applications) { "email" }
-      let(:previous_application_link) { vacancy.application_link }
-
-      it "resets application link" do
-        expect { update_receive_application }
-          .to change(vacancy, :application_link)
-          .from(previous_application_link).to("")
-      end
-    end
-  end
-
   context "when changing additional documents" do
     let(:vacancy) { build(:vacancy, :with_supporting_documents) }
     let(:previous_supporting_documents) { vacancy.supporting_documents }
@@ -113,45 +73,6 @@ RSpec.describe Resettable do
 
     it "removes all previous supporting documents" do
       expect(vacancy.supporting_documents).to all(have_received(:purge_later))
-    end
-  end
-
-  context "when changing contact number provided" do
-    subject(:update_contact_number_provided) { vacancy.update(contact_number_provided: false) }
-
-    let(:vacancy) { build(:vacancy, contact_number_provided: true, contact_number: "1111111111") }
-    let(:previous_contact_number) { vacancy.contact_number }
-
-    it "resets contact number" do
-      expect { update_contact_number_provided }
-        .to change(vacancy, :contact_number)
-        .from(previous_contact_number).to(nil)
-    end
-  end
-
-  context "when changing further details provided" do
-    subject(:update_further_details_provided) { vacancy.update(further_details_provided: false) }
-
-    let(:vacancy) { build(:vacancy, further_details_provided: true, further_details: "test") }
-    let(:previous_further_details) { vacancy.further_details }
-
-    it "resets further details" do
-      expect { update_further_details_provided }
-        .to change(vacancy, :further_details)
-        .from(previous_further_details).to(nil)
-    end
-  end
-
-  context "when changing benefits" do
-    subject(:update_benefits) { vacancy.update(benefits: false) }
-
-    let(:vacancy) { build(:vacancy, benefits: true, benefits_details: "test") }
-    let(:previous_benefits_details) { vacancy.benefits_details }
-
-    it "resets benefits details" do
-      expect { update_benefits }
-        .to change(vacancy, :benefits_details)
-        .from(previous_benefits_details).to(nil)
     end
   end
 end

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -71,6 +71,7 @@ FactoryBot.define do
     job_roles { %w[teacher] }
     ect_status { :ect_unsuitable }
     pay_scale { factory_sample(salaries) }
+    phases { %w[primary] }
     publish_on { Date.current }
     salary { factory_sample(salaries) }
     hourly_rate { "£25 per hour" }
@@ -99,6 +100,7 @@ FactoryBot.define do
 
     trait :it_support do
       job_roles { %w[it_support] }
+      key_stages { %w[] }
     end
 
     trait :secondary do

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -71,7 +71,7 @@ FactoryBot.define do
     job_roles { %w[teacher] }
     ect_status { :ect_unsuitable }
     pay_scale { factory_sample(salaries) }
-    phases { %w[primary] }
+    # phases { %w[primary] }
     publish_on { Date.current }
     salary { factory_sample(salaries) }
     hourly_rate { "£25 per hour" }

--- a/spec/factories/vacancies.rb
+++ b/spec/factories/vacancies.rb
@@ -71,7 +71,6 @@ FactoryBot.define do
     job_roles { %w[teacher] }
     ect_status { :ect_unsuitable }
     pay_scale { factory_sample(salaries) }
-    # phases { %w[primary] }
     publish_on { Date.current }
     salary { factory_sample(salaries) }
     hourly_rate { "£25 per hour" }

--- a/spec/jobs/import_from_vacancy_source_job_spec.rb
+++ b/spec/jobs/import_from_vacancy_source_job_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe ImportFromVacancySourceJob do
           "job_location" => nil,
           "job_roles" => ["teacher"],
           "job_title" => "",
-          "key_stages" => ["ks1"],
+          "key_stages" => [],
           "latest_start_date" => nil,
           "listed_elsewhere" => nil,
           "other_extension_reason_details" => nil,

--- a/spec/jobs/import_from_vacancy_source_job_spec.rb
+++ b/spec/jobs/import_from_vacancy_source_job_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe ImportFromVacancySourceJob do
         expect(FailedImportedVacancy.first.import_errors).to include("phases:[can't be blank]")
         expect(FailedImportedVacancy.first.vacancy).to eq(
           "about_school" => "test",
-          "actual_salary" => "",
+          "actual_salary" => nil,
           "anonymise_applications" => false,
           "application_email" => nil,
           "application_link" => nil,
@@ -128,7 +128,7 @@ RSpec.describe ImportFromVacancySourceJob do
           "external_advert_url" => "https://example.com/jobs/123",
           "external_reference" => "invalid_vac_ref",
           "external_source" => "may_the_feed_be_with_you",
-          "fixed_term_contract_duration" => "",
+          "fixed_term_contract_duration" => nil,
           "flexi_working" => "Debitis id voluptate cumque iusto quod ut libero facere repellendus est perspiciatis rem labore voluptatibus",
           "further_details" => "details",
           "further_details_provided" => true,
@@ -140,7 +140,7 @@ RSpec.describe ImportFromVacancySourceJob do
           "job_location" => nil,
           "job_roles" => ["teacher"],
           "job_title" => "",
-          "key_stages" => [],
+          "key_stages" => ["ks1"],
           "latest_start_date" => nil,
           "listed_elsewhere" => nil,
           "other_extension_reason_details" => nil,

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -563,26 +563,6 @@ RSpec.describe Vacancy do
   end
 
   describe "#reset_dependent_fields" do
-    context "when changing working pattern to full time" do
-      subject { create(:vacancy, working_patterns: ["part_time"], actual_salary: "50000") }
-
-      before { subject.update working_patterns: ["full_time"] }
-
-      it "resets actual_salary field" do
-        expect(subject.actual_salary).to be_blank
-      end
-    end
-
-    context "when changing contract type to permanent" do
-      subject { create(:vacancy, contract_type: "fixed_term", fixed_term_contract_duration: "8 months") }
-
-      before { subject.update contract_type: "permanent" }
-
-      it "resets fixed_term_contract_duration field" do
-        expect(subject.fixed_term_contract_duration).to be_blank
-      end
-    end
-
     context "when phase is changed from primary to secondary" do
       subject { create(:vacancy, phases: ["primary"], subjects: %w[English]) }
 

--- a/spec/presenters/vacancy_decorator_spec.rb
+++ b/spec/presenters/vacancy_decorator_spec.rb
@@ -20,19 +20,19 @@ RSpec.shared_examples "a fields that outputs the correct HTML" do |field|
     let(:vacancy) { build_stubbed(:vacancy, field => well_formatted_text) }
     let(:well_formatted_text) do
       "Some list\n" \
-      "Some itmes to follow:\n" \
-      "·   Item number one\n" \
-      "·   Item number two\n" \
-      "·   Item number three\n" \
-      "Apply now. "
+        "Some itmes to follow:\n" \
+        "·   Item number one\n" \
+        "·   Item number two\n" \
+        "·   Item number three\n" \
+        "Apply now. "
     end
     let(:well_formatted_html) do
       "<p>Some list\n<br />" \
-      "Some itmes to follow:\n<br />" \
-      "•   Item number one\n<br />" \
-      "•   Item number two\n<br />" \
-      "•   Item number three\n<br />" \
-      "Apply now. </p>"
+        "Some itmes to follow:\n<br />" \
+        "•   Item number one\n<br />" \
+        "•   Item number two\n<br />" \
+        "•   Item number three\n<br />" \
+        "Apply now. </p>"
     end
 
     it "does not reformat text" do
@@ -45,24 +45,24 @@ RSpec.shared_examples "a fields that outputs the correct HTML" do |field|
 
     let(:badly_formatted_text) do
       " Sentence one. Sentence two.\n" \
-      "Paragraph two. Qualifications:\n" \
-      "•    Skill one." \
-      "•    Skill two." \
-      "•    Skill three.\n" \
-      "Penultimate paragraph.\n" \
-      "Last paragraph \n"
+        "Paragraph two. Qualifications:\n" \
+        "•    Skill one." \
+        "•    Skill two." \
+        "•    Skill three.\n" \
+        "Penultimate paragraph.\n" \
+        "Last paragraph \n"
     end
 
     let(:well_formatted_html) do
       "<p> Sentence one. Sentence two.\n<br />" \
-      "Paragraph two. Qualifications:\n<br />" \
-      "<ul>" \
-      "<li>    Skill one.</li>" \
-      "<li>    Skill two.</li>" \
-      "<li>    Skill three.</li>" \
-      "</ul>" \
-      "\n<br />Penultimate paragraph.\n<br />" \
-      "Last paragraph </p>"
+        "Paragraph two. Qualifications:\n<br />" \
+        "<ul>" \
+        "<li>    Skill one.</li>" \
+        "<li>    Skill two.</li>" \
+        "<li>    Skill three.</li>" \
+        "</ul>" \
+        "\n<br />Penultimate paragraph.\n<br />" \
+        "Last paragraph </p>"
     end
 
     it "transforms badly formatted inline bullet point symbols into validly formatted <li> tags" do
@@ -77,20 +77,20 @@ RSpec.shared_examples "a fields that outputs the correct HTML" do |field|
 
       let(:well_formatted_text) do
         "<div><!--block-->&nbsp;</div><div><!--block--><strong>Some list</strong>&nbsp;<br><br></div>" \
-        "<div><!--block-->Some itmes to follow:&nbsp;<br><br></div>" \
-        "<div><!--block-->· &nbsp; Item number one;&nbsp;<br><br></div>" \
-        "<div><!--block-->· &nbsp; Item number two;&nbsp;<br><br></div>" \
-        "<div><!--block-->· &nbsp; Item number three;&nbsp;<br><br></div>" \
-        "<div><!--block-->Apply now.&nbsp;</div>"
+          "<div><!--block-->Some itmes to follow:&nbsp;<br><br></div>" \
+          "<div><!--block-->· &nbsp; Item number one;&nbsp;<br><br></div>" \
+          "<div><!--block-->· &nbsp; Item number two;&nbsp;<br><br></div>" \
+          "<div><!--block-->· &nbsp; Item number three;&nbsp;<br><br></div>" \
+          "<div><!--block-->Apply now.&nbsp;</div>"
       end
 
       let(:well_formatted_html) do
         "<p> <strong>Some list</strong> </p>\n\n" \
-        "<p>Some itmes to follow: </p>\n\n" \
-        "<p>•   Item number one; </p>\n\n" \
-        "<p>•   Item number two; </p>\n\n" \
-        "<p>•   Item number three; </p>\n\n" \
-        "<p>Apply now. </p>"
+          "<p>Some itmes to follow: </p>\n\n" \
+          "<p>•   Item number one; </p>\n\n" \
+          "<p>•   Item number two; </p>\n\n" \
+          "<p>•   Item number three; </p>\n\n" \
+          "<p>Apply now. </p>"
       end
 
       it "does not reformat text" do
@@ -103,24 +103,24 @@ RSpec.shared_examples "a fields that outputs the correct HTML" do |field|
 
       let(:badly_formatted_text) do
         "<div><!--block-->&nbsp;</div><div><!--block-->Sentence one. Sentence two.&nbsp;<br><br></div>" \
-        "<div><!--block-->Paragraph two. Qualifications:&nbsp;<br><br></div>" \
-        "<div><!--block-->•&nbsp; &nbsp; Skill one.&nbsp;</div>" \
-        "<div><!--block-->•&nbsp; &nbsp; Skill two.&nbsp;</div>" \
-        "<div><!--block-->•&nbsp; &nbsp; Skill three.&nbsp;<br><br></div>" \
-        "<div><!--block-->Penultimate paragraph.&nbsp;<br><br>" \
-        "Last paragraph &nbsp;<br><br></div><div>"
+          "<div><!--block-->Paragraph two. Qualifications:&nbsp;<br><br></div>" \
+          "<div><!--block-->•&nbsp; &nbsp; Skill one.&nbsp;</div>" \
+          "<div><!--block-->•&nbsp; &nbsp; Skill two.&nbsp;</div>" \
+          "<div><!--block-->•&nbsp; &nbsp; Skill three.&nbsp;<br><br></div>" \
+          "<div><!--block-->Penultimate paragraph.&nbsp;<br><br>" \
+          "Last paragraph &nbsp;<br><br></div><div>"
       end
 
       let(:well_formatted_html) do
         "<p> Sentence one. Sentence two. </p>\n\n" \
-        "<p>Paragraph two. Qualifications: </p>\n\n" \
-        "<p></p><ul>\n" \
-        "<li>  Skill one.</li>\n" \
-        "<li>  Skill two.</li>\n" \
-        "<li>  Skill three.</li>\n" \
-        "</ul>\n\n" \
-        "<p>Penultimate paragraph. </p>\n\n" \
-        "<p>Last paragraph  </p>"
+          "<p>Paragraph two. Qualifications: </p>\n\n" \
+          "<p></p><ul>\n" \
+          "<li>  Skill one.</li>\n" \
+          "<li>  Skill two.</li>\n" \
+          "<li>  Skill three.</li>\n" \
+          "</ul>\n\n" \
+          "<p>Penultimate paragraph. </p>\n\n" \
+          "<p>Last paragraph  </p>"
       end
 
       it "transforms badly formatted inline bullet point symbols into validly formatted <li> tags" do
@@ -137,7 +137,13 @@ RSpec.describe VacancyDecorator do
   describe "#benefits_details" do
     subject { decorated }
 
+    let(:vacancy) { build_stubbed(:vacancy, benefits: false, benefits_details: "test") }
+
     it_behaves_like "a fields that outputs the correct HTML", :benefits_details
+
+    it "resets benefits details" do
+      expect(decorated.benefits_details).to be_nil
+    end
   end
 
   describe "#working_patterns_for_job_schema" do
@@ -359,6 +365,46 @@ RSpec.describe VacancyDecorator do
 
     it "resets fixed term contract duration" do
       expect(decorated.fixed_term_contract_duration).to be_blank
+    end
+  end
+
+  describe "#receive_applications" do
+    let(:vacancy) { build_stubbed(:draft_vacancy, :apply_via_website, enable_job_applications: true) }
+
+    it "resets receive application" do
+      expect(decorated.receive_applications).to be_nil
+    end
+  end
+
+  describe "#contact_number" do
+    let(:vacancy) { build_stubbed(:vacancy, contact_number_provided: false, contact_number: "1111111111") }
+
+    it "resets contact number" do
+      expect(decorated.contact_number).to be_nil
+    end
+  end
+
+  describe "#application_email" do
+    let(:vacancy) { build_stubbed(:vacancy, enable_job_applications: false, receive_applications: "website", application_email: Faker::Internet.email(domain: TEST_EMAIL_DOMAIN)) }
+
+    it "resets application email" do
+      expect(decorated.application_email).to be_nil
+    end
+  end
+
+  describe "#application_link" do
+    let(:vacancy) { build_stubbed(:vacancy, enable_job_applications: false, receive_applications: "email", application_link: "www.test.com") }
+
+    it "resets application link" do
+      expect(decorated.application_link).to be_nil
+    end
+  end
+
+  describe "#further_details" do
+    let(:vacancy) { build_stubbed(:vacancy, further_details_provided: false, further_details: "test") }
+
+    it "resets further details" do
+      expect(decorated.further_details).to be_nil
     end
   end
 end

--- a/spec/presenters/vacancy_decorator_spec.rb
+++ b/spec/presenters/vacancy_decorator_spec.rb
@@ -345,4 +345,20 @@ RSpec.describe VacancyDecorator do
       end
     end
   end
+
+  describe "#actual_salary" do
+    let(:vacancy) { build_stubbed(:vacancy, working_patterns: %w[full_time], actual_salary: "50000") }
+
+    it "resets actual_salary field" do
+      expect(decorated.actual_salary).to be_blank
+    end
+  end
+
+  describe "#fixed_term_contract_duration" do
+    let(:vacancy) { build_stubbed(:vacancy, contract_type: "permanent", fixed_term_contract_duration: "6 months") }
+
+    it "resets fixed term contract duration" do
+      expect(decorated.fixed_term_contract_duration).to be_blank
+    end
+  end
 end

--- a/spec/system/jobseekers/jobseekers_can_complete_a_job_application_spec.rb
+++ b/spec/system/jobseekers/jobseekers_can_complete_a_job_application_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Jobseekers can complete a job application" do
           end
         end
 
-        describe "accessibility", :a11y do
+        describe "accessibility", :a11y, :retry do
           it "passes a11y" do
             expect(page).to be_axe_clean
           end

--- a/spec/views/publishers/vacancies/show.html.slim_spec.rb
+++ b/spec/views/publishers/vacancies/show.html.slim_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe "publishers/vacancies/show" do
       expect(rendered).to have_content(vacancy.working_patterns_details)
 
       expect(rendered).to have_content(vacancy.salary)
-      expect(rendered).to have_content(vacancy.actual_salary)
       expect(rendered).to have_content(vacancy.pay_scale)
 
       expect(rendered).to have_content(strip_tags(vacancy.benefits_details))


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/tvcXdl8D/3222-vacancy-modelling-move-from-vacancy-discarding-attributes-value-to-failing-validation

## Changes in this PR:

Move non-searchable vacancy data changes from resettable into VacancyDecorator