### PR TITLE
2855 - Syntax error in delete_review_app

### DIFF
--- a/.github/workflows/delete_review_app.yml
+++ b/.github/workflows/delete_review_app.yml
@@ -123,9 +123,9 @@ jobs:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
 
       - name: Terraform destroy (on PR closed)
-        run: 
+        run: |
           echo "Deleting PR ${PR_NUMBER}"
-          make review ci terraform-app-destroy pr_id=${{env.PR_NUMBER}}
+          make review ci terraform-app-destroy pr_id=${{ env.PR_NUMBER }}
 
       - name: Delete Terraform Statefile
         run: ./bin/delete-state-file ${{env.PR_NUMBER}}
@@ -145,5 +145,5 @@ jobs:
           service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}
           message: |
             Failed deletion of review app PR ${{env.PR_NUMBER}}
-            Pull Requst: ${{ env.LINK_TO_PR }}
+            Pull Request: ${{ env.LINK_TO_PR }}
             Review app: ${{ env.LINK_TO_APP }}

--- a/bin/delete-state-file
+++ b/bin/delete-state-file
@@ -8,12 +8,19 @@ statefile="review-pr-${PR}.tfstate"
 prefix="review/${statefile}"
 key=$prefix
 
-list_statefile_versionId=$(aws s3api list-object-versions --bucket ${bucket_name} --prefix "${prefix}" --query 'Versions[*].[VersionId]' --output text)
+list_statefile_versionId=$(
+  aws s3api list-object-versions --bucket "$bucket_name" --prefix "$prefix" --query 'Versions[*].[VersionId]' --output text
+)
 
-echo Deleting Review app\'s state file
+echo "Deleting Review app's state file"
+
+if [[ -z "$list_statefile_versionId" || "$list_statefile_versionId" == "None" ]]; then
+    echo "No state file found for PR ${PR}. Skipping deletion."
+    exit 0
+fi
 
 for versionId in $list_statefile_versionId
-    do
-        echo "$versionId"
-        aws s3api delete-object --bucket ${bucket_name} --key "$key" --version-id "$versionId"
-    done
+do
+    echo "$versionId"
+    aws s3api delete-object --bucket "$bucket_name" --key "$key" --version-id "$versionId"
+done


### PR DESCRIPTION
## Trello card URL

[Link](https://trello.com/c/ZWznDc8Y/2855-add-review-app-cleanup-workflow)

## Context

The review app reconcile workflow seemed to be failing sporadically due to the fact that the Terraform state files for the review apps were no longer present in the S3 bucket.

Upon investigation, it was determined that the **delete_review_app.yml** file contained a small syntax error which caused it not to run. This meant the review app deletion failed, but the Terraform state file deletion completed successfully.

Due to this, every week there was a build up of review apps in AKS that have no related state files in S3.

## Changes in this PR

- Fixed **delete_review_app.yml** code to make the deletion step a multiline command (was running as a simple echo command previously)
- Updated **delete-state-file** bash script to make it more resilient to failure and to thereby ensure that the reconcile process does not fail at this step

## Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Applied DevOps label
- [x] Tested by running locally