### PR TITLE
Simplify rack attack rules

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,6 +1,20 @@
 # Throttle counters and fail2ban strikes/bans are stored in Rack::Attack.cache, which defaults to
 # Rails.cache — Redis in production, so state is shared across all app instances.
 
+# Send a Retry-After header on 429s so throttled clients (in particular ATS API partners) know how
+# long to back off for, instead of retrying blind.
+Rack::Attack.throttled_response_retry_after_header = true
+
+####################################################################################################################
+# CLOUDFRONT WAF
+# A CloudFront WAF rate-based rule sits in front of this app and blocks any IP exceeding 900
+# requests per 5 minutes (3 req/sec) — see terraform/app/modules/cloudfront/main.tf and
+# `waf_ip_rate_limit` in terraform/workspace-variables/*.tfvars.json. Notes for rules added here:
+#   - A rule looser than 3 req/sec can never fire for origin traffic, since the edge blocks first.
+#   - The WAF only aggregates by IP, so anything keyed by API key, email or path has to live here.
+#   - The WAF blocks with an opaque edge 403; our throttles are scoped 429s, logged below.
+####################################################################################################################
+
 # Allow rack_attack to use Rails's remote_ip, which resolves the real client IP via the trusted
 # proxy chain. As we are behind a CDN, Rack's default ip could return the CDN node's address,
 # making all clients behind that node share the same throttle counters and IP bans.
@@ -15,6 +29,15 @@ class Rack::Attack
   # CONSTANTS DEFINITIONS
   # Since this is instantiated once at boot time, we can define constants here to avoid re-evaluating them on every request.
   ##########################################################################################################################
+
+  # Kubernetes liveness/startup probes hit this path every 5 seconds from the node's kubelet IP, so
+  # all pods on a node would otherwise share one throttle counter against it. It does no work
+  # (renders a static JSON body, no DB access), so it's safe to exempt entirely — safelisting it
+  # also means a blocklisted IP can still reach it.
+  HEALTH_CHECK_PATH = "/check".freeze
+  safelist("health check probes") do |request|
+    request.path == HEALTH_CHECK_PATH
+  end
 
   BLOCKED_IPS = ENV.fetch("RACK_ATTACK_BLOCKED_IPS", "").split(",").map(&:strip).freeze # Array of IPs to block
   blocklist("block all requests from a banned list of remote IPs") do |request|
@@ -37,11 +60,8 @@ class Rack::Attack
   # fallback auth POSTs). 50 auth requests in 10 minutes is far beyond any individual legitimate user
   # — a normal login is a single callback or form POST, so a human would need a submission every ~12s
   # for 10 minutes straight — so this only bites automated brute-forcing. It sits at or below the
-  # per-endpoint throttles' 10-minute allowances (login/fallback 5/min = 50/10min; OIDC 15/min =
-  # 150/10min), so fail2ban, not the throttles, is the binding limit on sustained auth volume. The one
-  # caveat is shared/NAT IPs (e.g. a school or trust behind one address) whose users' auth requests
-  # aggregate onto the same counter; the ban is auth-scoped, so such an IP can still browse the rest of
-  # the site while locked out of auth for FAIL2BAN_BANTIME.
+  # per-endpoint throttles' 10-minute allowances (auth attempts 5/min = 50/10min; OIDC 15/min =
+  # 150/10min), so fail2ban, not the throttles, is the binding limit on sustained auth volume.
   FAIL2BAN_MAXRETRY = 50 # Ban an IP after this many auth requests...
   FAIL2BAN_FINDTIME = 10.minutes # ...within this window...
   FAIL2BAN_BANTIME = 1.hour # ...for this long.
@@ -60,19 +80,29 @@ class Rack::Attack
   #     blocklist short-circuits so the throttles no longer run for that IP.
   ####################################################################################################################
 
+  # Whether a request targets one of our OIDC authentication callback endpoints (GET).
+  def self.oidc_callback_request?(request)
+    request.get? && OIDC_CALLBACK_PATHS.include?(request.path)
+  end
+
+  # Whether a request targets one of our credential-based auth endpoints (jobseeker sign-in or the
+  # fallback auth POSTs — login keys, fallback sessions, account transfers).
+  def self.credential_auth_request?(request)
+    request.post? &&
+      (request.path == JOBSEEKER_SIGN_IN_PATH || request.path.start_with?(*FALLBACK_AUTH_PATH_PREFIXES))
+  end
+
   # Whether a request targets one of our authentication endpoints (union of the auth throttle matchers).
   # Used to gate the fail2ban blocklist so that only auth requests count towards the ban, and non-auth traffic is never blocked.
   # It also saves us from having to query the ban cache for every request, since the blocklist is checked
   # first and only hits the cache if auth_request? returns true.
   def self.auth_request?(request)
-    (OIDC_CALLBACK_PATHS.include?(request.path) && request.get?) ||
-      (request.path == JOBSEEKER_SIGN_IN_PATH && request.post?) ||
-      (request.post? && request.path.start_with?(*FALLBACK_AUTH_PATH_PREFIXES))
+    oidc_callback_request?(request) || credential_auth_request?(request)
   end
 
   # Allow2Ban lets requests through while counting strikes, and bans once FAIL2BAN_MAXRETRY auth
   # requests are seen within FAIL2BAN_FINDTIME. The ban is auth-scoped (gated on auth_request?):
-  # a shared IP (e.g. a school NAT) that trips the limit can still browse the rest of the site.
+  # a shared IP that trips the limit can still browse the rest of the site.
   blocklist("fail2ban auth brute-forcers") do |request|
     next false unless auth_request?(request)
 
@@ -91,19 +121,21 @@ end
 general_throttle = lambda do |request|
   request.remote_ip unless request.path.start_with?(Rack::Attack::ATS_API_PATH_PREFIX) # ATS API clients have their own dedicated throttle below
 end
-Rack::Attack.throttle("requests by remote ip per 4 secs", limit: 10, period: 4, &general_throttle) # Allow 10 requests in 4 seconds (2.5 req/sec)
 Rack::Attack.throttle("requests by remote ip per minute", limit: 105, period: 60, &general_throttle) # Allow 105 requests in 1 minute (1.75 req/sec over 1 minute)
-Rack::Attack.throttle("requests by remote ip per 10 minutes", limit: 900, period: 600, &general_throttle) # Allow 900 requests in 10 minutes (1.5 req/sec over 10 minutes)
 Rack::Attack.throttle("requests by remote ip per hour", limit: 4500, period: 3600, &general_throttle) # Allow 4500 requests in 1 hour (1.25 req/sec over an hour)
-Rack::Attack.throttle("requests by remote ip per 12 hours", limit: 43_200, period: 43_200, &general_throttle) # Allow 43200 requests in 12 hours (1 req/sec over 12 hours)
 
 ####################################################################################################################
 # ATS API CLIENT THROTTLING
 # More relaxed throttling for ATS API clients, keyed by API key (falling back to IP for keyless requests).
+#
+# Limit is 150/min rather than the CloudFront WAF's ~180/min average (900 per 5 min, aggregated by
+# IP) so a client relying on their documented allowance gets a Rails 429 (logged, with Retry-After)
+# instead of an opaque CloudFront 403 with nothing in our logs. Do not raise this above the WAF
+# ceiling — requests beyond it are blocked at the edge regardless of what we allow here.
 ####################################################################################################################
 
 # "X-Api-Key" appears in the Rack env as "HTTP_X_API_KEY".
-Rack::Attack.throttle("ATS API requests by client", limit: 600, period: 60) do |request|
+Rack::Attack.throttle("ATS API requests by client", limit: 150, period: 60) do |request|
   if request.path.start_with?(Rack::Attack::ATS_API_PATH_PREFIX)
     request.get_header("HTTP_X_API_KEY").presence || request.remote_ip
   end
@@ -117,16 +149,15 @@ end
 # Throttle OIDC authentication callback endpoints (GOV.UK One Login and DfE Sign In) by IP to
 # prevent brute-forcing of authorization codes
 Rack::Attack.throttle("limit OIDC auth callbacks by IP", limit: 15, period: 60) do |request|
-  if Rack::Attack::OIDC_CALLBACK_PATHS.include?(request.path) && request.get?
-    request.remote_ip
-  end
+  request.remote_ip if Rack::Attack.oidc_callback_request?(request)
 end
 
-# Throttle login attempts for jobseeker fallback auth by IP
-Rack::Attack.throttle("limit jobseeker logins by IP", limit: 5, period: 60) do |request|
-  if request.path == Rack::Attack::JOBSEEKER_SIGN_IN_PATH && request.post?
-    request.remote_ip
-  end
+# Throttle credential-based auth attempts by IP: jobseeker sign-in POSTs and the fallback auth POSTs
+# (login keys, fallback sessions, account transfers) share a single counter, since both are the same
+# kind of attempt to establish a session and a brute-forcer can otherwise just alternate between them
+# to double their effective allowance.
+Rack::Attack.throttle("limit auth attempts by IP", limit: 5, period: 60) do |request|
+  request.remote_ip if Rack::Attack.credential_auth_request?(request)
 end
 
 # Throttle login attempts for jobseeker fallback auth by email
@@ -134,14 +165,6 @@ Rack::Attack.throttle("limit jobseeker logins by email", limit: 5, period: 60) d
   if request.path == Rack::Attack::JOBSEEKER_SIGN_IN_PATH && request.post?
     jobseeker_params = request.params["jobseeker"]
     jobseeker_params["email"].to_s.downcase.gsub(/\s+/, "").presence if jobseeker_params.is_a?(Hash)
-  end
-end
-
-# Throttle email-based fallback auth endpoints (magic links, fallback sessions, account transfers) by IP
-# to prevent email bombing and brute-forcing of login keys/codes
-Rack::Attack.throttle("limit fallback auth requests by IP", limit: 5, period: 60) do |request|
-  if request.post? && request.path.start_with?(*Rack::Attack::FALLBACK_AUTH_PATH_PREFIXES)
-    request.remote_ip
   end
 end
 

--- a/documentation/service/integrations/publisher-ats-api.md
+++ b/documentation/service/integrations/publisher-ats-api.md
@@ -9,6 +9,17 @@ The API clients will be able to do these operations:
 - Delete a vacancy
 - List all their vacancies
 
+## Rate limiting
+
+ATS API requests are throttled to 150 requests per minute per client (see the `"ATS API requests by
+client"` throttle in [config/initializers/rack_attack.rb](/config/initializers/rack_attack.rb)).
+Exceeding it returns `HTTP 429` with a `Retry-After` header, as documented for clients in the
+[API description](/spec/swagger_helper.rb).
+
+150/min is set below the CloudFront WAF's rate-based rule (`waf_ip_rate_limit` in
+[terraform/app/modules/cloudfront/main.tf](/terraform/app/modules/cloudfront/main.tf)), which blocks
+a source IP outright with an opaque `403` at roughly 180 requests/minute. Keep this throttle below
+that ceiling, or clients will hit the edge block instead of a documented, resettable `429`.
 
 ## Onboarding new clients
 

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -16,8 +16,25 @@ RSpec.describe "Rack::Attack" do
     Rack::Attack::Request.new(Rack::MockRequest.env_for(path, env_options))
   end
 
+  describe "health check safelist" do
+    it "is neither throttled nor blocked, even when the IP is blocklisted" do
+      stub_const("Rack::Attack::BLOCKED_IPS", %w[127.0.0.1])
+
+      freeze_time do
+        120.times { get "/check" }
+      end
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
   describe "general requests throttles" do
-    let(:throttle) { Rack::Attack.throttles["requests by remote ip per 4 secs"] }
+    let(:throttle) { Rack::Attack.throttles["requests by remote ip per minute"] }
+
+    it "allows 105 requests per minute" do
+      expect(throttle.limit).to eq(105)
+      expect(throttle.period).to eq(60)
+    end
 
     it "keys requests by remote IP" do
       expect(throttle.block.call(build_request("/jobs"))).to eq("1.2.3.4")
@@ -31,8 +48,8 @@ RSpec.describe "Rack::Attack" do
   describe "ATS API throttle" do
     let(:throttle) { Rack::Attack.throttles["ATS API requests by client"] }
 
-    it "allows more requests than the general throttles" do
-      expect(throttle.limit).to eq(600)
+    it "allows fewer requests per minute than the CloudFront WAF's per-IP limit" do
+      expect(throttle.limit).to eq(150)
       expect(throttle.period).to eq(60)
     end
 
@@ -68,16 +85,31 @@ RSpec.describe "Rack::Attack" do
     end
   end
 
-  describe "jobseeker logins by IP throttle" do
-    let(:throttle) { Rack::Attack.throttles["limit jobseeker logins by IP"] }
+  describe "auth attempts by IP throttle" do
+    let(:throttle) { Rack::Attack.throttles["limit auth attempts by IP"] }
 
     it "keys POST requests to the jobseeker sign-in endpoint by remote IP" do
       request = build_request("/jobseekers/sign-in", method: "POST")
       expect(throttle.block.call(request)).to eq("1.2.3.4")
     end
 
+    it "keys POST requests to the fallback auth endpoints by remote IP" do
+      paths = %w[
+        /jobseekers/login_keys
+        /publishers/login_keys
+        /publishers/login_keys/some-id/consume
+        /support-users/fallback_sessions
+        /jobseekers/request_account_transfer_email
+        /jobseekers/account_transfer
+      ]
+      paths.each do |path|
+        expect(throttle.block.call(build_request(path, method: "POST"))).to eq("1.2.3.4")
+      end
+    end
+
     it "does not match other HTTP methods" do
       expect(throttle.block.call(build_request("/jobseekers/sign-in"))).to be_nil
+      expect(throttle.block.call(build_request("/jobseekers/login_keys"))).to be_nil
     end
 
     it "does not match other paths" do
@@ -108,34 +140,8 @@ RSpec.describe "Rack::Attack" do
     end
   end
 
-  describe "fallback auth throttle" do
-    let(:throttle) { Rack::Attack.throttles["limit fallback auth requests by IP"] }
-
-    it "keys POST requests to the fallback auth endpoints by remote IP" do
-      paths = %w[
-        /jobseekers/login_keys
-        /publishers/login_keys
-        /publishers/login_keys/some-id/consume
-        /support-users/fallback_sessions
-        /jobseekers/request_account_transfer_email
-        /jobseekers/account_transfer
-      ]
-      paths.each do |path|
-        expect(throttle.block.call(build_request(path, method: "POST"))).to eq("1.2.3.4")
-      end
-    end
-
-    it "does not match other HTTP methods" do
-      expect(throttle.block.call(build_request("/jobseekers/login_keys"))).to be_nil
-    end
-
-    it "does not match other paths" do
-      expect(throttle.block.call(build_request("/jobs", method: "POST"))).to be_nil
-    end
-  end
-
   describe "throttled requests" do
-    it "returns 429 and logs a warning when a throttle limit is exceeded" do
+    it "returns 429 with a Retry-After header, and logs a warning, when a throttle limit is exceeded" do
       allow(Rails.logger).to receive(:warn)
 
       freeze_time do
@@ -143,9 +149,10 @@ RSpec.describe "Rack::Attack" do
       end
 
       expect(response).to have_http_status(:too_many_requests)
+      expect(response.headers["Retry-After"]).to be_present
       expect(Rails.logger).to have_received(:warn)
         .with(a_string_matching(/\[rack-attack\] Throttled request/),
-              hash_including(matched: "limit jobseeker logins by IP", ip: "127.0.0.1", path: "/jobseekers/sign-in"))
+              hash_including(matched: "limit auth attempts by IP", ip: "127.0.0.1", path: "/jobseekers/sign-in"))
     end
 
     it "does not apply the general throttles to ATS API requests" do
@@ -154,14 +161,6 @@ RSpec.describe "Rack::Attack" do
       end
 
       expect(response).to have_http_status(:unauthorized)
-    end
-
-    it "applies the general throttles to non-ATS API requests" do
-      freeze_time do
-        11.times { get "/check" }
-      end
-
-      expect(response).to have_http_status(:too_many_requests)
     end
   end
 
@@ -173,12 +172,12 @@ RSpec.describe "Rack::Attack" do
     it "returns 403 and logs a warning" do
       allow(Rails.logger).to receive(:warn)
 
-      get "/check"
+      get "/jobs"
 
       expect(response).to have_http_status(:forbidden)
       expect(Rails.logger).to have_received(:warn)
         .with(a_string_matching(/\[rack-attack\] Blocked request/),
-              hash_including(matched: "block all requests from a banned list of remote IPs", ip: "127.0.0.1", path: "/check"))
+              hash_including(matched: "block all requests from a banned list of remote IPs", ip: "127.0.0.1", path: "/jobs"))
     end
   end
 
@@ -218,7 +217,7 @@ RSpec.describe "Rack::Attack" do
     it "does not ban non-auth traffic (the ban is auth-scoped)" do
       freeze_time do
         (Rack::Attack::FAIL2BAN_MAXRETRY + 1).times { get "/auth/dfe" }
-        get "/check"
+        get "/jobs"
       end
 
       expect(response).not_to have_http_status(:forbidden)

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -147,11 +147,23 @@ RSpec.configure do |config|
           If you ever need a new or replacement key, let us know, and we’ll assist you with the process.
           You can email us at [teachingvacancies.ats@education.gov.uk](mailto:teachingvacancies.ats@education.gov.uk).
 
+          ## Rate limiting
+
+          Requests are limited to 150 per minute per API key (or per source IP for unauthenticated requests).
+          If you exceed this, the API responds with `HTTP 429` (Too Many Requests) and a `Retry-After`
+          header giving the number of seconds to wait before your next request.
+
+          A separate, coarser limit also applies per source IP at the network level. If you sustain a rate
+          well above 150 requests per minute, you may see connections rejected there instead of receiving
+          a `429` response.
+
           **Base URL**: `/ats-api/v1`
 
           **Supported Formats**: JSON
 
           **Authentication**: API key in `X-Api-Key`
+
+          **Rate limit**: 150 requests/minute
 
         DESCRIPTION
       },


### PR DESCRIPTION
## Trello card URL

## Changes in this PR:

**Simplifies Rack Attack rules ahead of Solid Cache migration.**
More rules mean more cache writes per visit. So simplifying the rules will help with a more sane amount of writes per visit.

**Adapts the API throttling to the Cloud throttling**
Our API throttling limits were higher than the cloud rate throttling applied to our service. So the limits would never be reached.
Adapted them and documented the rate throttling in our internal docs and API public docs.


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
