### PR TITLE
Handle vacancies with no attached application form in document_filename

### DIFF
--- a/app/helpers/documents_helper.rb
+++ b/app/helpers/documents_helper.rb
@@ -13,6 +13,8 @@ module DocumentsHelper
   end
 
   def document_filename(vacancy, document)
+    return "" if document.blob.nil?
+
     if document.blob.malware_scan_clean?
       govuk_link_to "#{document.filename}, #{number_to_human_size(document.byte_size)}", job_document_path(vacancy, document.id)
     else

--- a/spec/helpers/documents_helper_spec.rb
+++ b/spec/helpers/documents_helper_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe DocumentsHelper do
+  describe "#document_filename" do
+    subject(:document_filename) { helper.document_filename(vacancy, vacancy.application_form) }
+
+    context "when the document has passed malware scanning" do
+      let(:vacancy) { create(:vacancy, :with_uploaded_application_form) }
+
+      it "returns a link to the document" do
+        expect(document_filename).to include(job_document_path(vacancy, vacancy.application_form.id))
+        expect(document_filename).to include("blank_job_spec.pdf")
+      end
+    end
+
+    context "when the document has not passed malware scanning" do
+      let(:vacancy) { create(:vacancy, :with_uploaded_application_form) }
+
+      before { vacancy.application_form.blob.malware_scan_pending! }
+
+      it "returns the filename without a link" do
+        expect(document_filename).not_to include("<a")
+        expect(document_filename).to include("blank_job_spec.pdf")
+      end
+    end
+
+    context "when no document is attached" do
+      let(:vacancy) { create(:vacancy, enable_job_applications: false, receive_applications: "uploaded_form") }
+
+      it "returns an empty string" do
+        expect(document_filename).to eq("")
+      end
+    end
+  end
+end

--- a/spec/requests/publishers/vacancies/application_forms_spec.rb
+++ b/spec/requests/publishers/vacancies/application_forms_spec.rb
@@ -3,6 +3,7 @@ require "dfe/analytics/rspec/matchers"
 
 RSpec.describe "Documents" do
   include ActionDispatch::TestProcess::FixtureFile
+  include ActiveJob::TestHelper
 
   let(:publisher) { create(:publisher) }
   let(:organisation) { build(:school) }
@@ -194,6 +195,39 @@ RSpec.describe "Documents" do
         it "is rejected even if the file extension suggests it is valid" do
           expect(response.body).to include(I18n.t("jobs.file_type_error_message", filename: "invalid_plain_text_file.txt", valid_file_types: valid_file_types))
         end
+      end
+    end
+  end
+
+  describe "DELETE #destroy" do
+    let(:request) { delete organisation_job_application_forms_path(vacancy.id) }
+
+    context "when the vacancy is published" do
+      let(:vacancy) { create(:vacancy, :with_uploaded_application_form, organisations: [organisation]) }
+
+      it "removes the application form" do
+        expect { perform_enqueued_jobs { request } }
+          .to change { vacancy.reload.application_form.attached? }.from(true).to(false)
+      end
+
+      it "redirects to the application form step" do
+        expect(request).to redirect_to(organisation_job_build_path(vacancy.id, :application_form))
+      end
+
+      it "leaves the vacancy published without an application form" do
+        perform_enqueued_jobs { request }
+
+        expect(vacancy.reload).to be_published
+        expect(vacancy.receive_applications).to eq("uploaded_form")
+      end
+    end
+
+    context "when the vacancy is a draft" do
+      let(:vacancy) { create(:draft_vacancy, :with_uploaded_application_form, organisations: [organisation]) }
+
+      it "removes the application form" do
+        expect { perform_enqueued_jobs { request } }
+          .to change { vacancy.reload.application_form.attached? }.from(true).to(false)
       end
     end
   end

--- a/spec/requests/publishers/vacancies/build_spec.rb
+++ b/spec/requests/publishers/vacancies/build_spec.rb
@@ -162,4 +162,20 @@ RSpec.describe "Job applications build" do
       end
     end
   end
+
+  describe "GET #show" do
+    context "when requesting the application form step for a published vacancy" do
+      let(:vacancy) { create(:vacancy, :with_uploaded_application_form, organisations: [school_one]) }
+
+      before { get(organisation_job_build_path(vacancy.id, :application_form)) }
+
+      it "renders the step" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "offers to remove the uploaded application form" do
+        expect(response.body).to include(organisation_job_application_forms_path(vacancy.id))
+      end
+    end
+  end
 end

--- a/spec/views/publishers/vacancies/vacancy_review_sections/_application_process.html.slim_spec.rb
+++ b/spec/views/publishers/vacancies/vacancy_review_sections/_application_process.html.slim_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe "publishers/vacancies/vacancy_review_sections/_application_process" do
+  let(:organisation) { create(:school) }
+  let(:step_process) { Publishers::Vacancies::VacancyStepProcess.new(:review, vacancy: vacancy, organisation: organisation) }
+
+  before do
+    render partial: "publishers/vacancies/vacancy_review_sections/application_process",
+           locals: { vacancy: vacancy.decorate, current_organisation: organisation, step_process: step_process }
+  end
+
+  context "when applications are received via an uploaded form" do
+    context "when the form has been uploaded" do
+      let(:vacancy) { create(:vacancy, :with_uploaded_application_form, organisations: [organisation]) }
+
+      it "links to the uploaded form" do
+        expect(rendered).to have_link(href: job_document_path(vacancy, vacancy.application_form.id), text: /blank_job_spec\.pdf/)
+      end
+    end
+
+    context "when no form is attached" do
+      let(:vacancy) do
+        create(:vacancy, enable_job_applications: false, receive_applications: "uploaded_form", organisations: [organisation])
+      end
+
+      it "renders the row without a document" do
+        expect(rendered).to have_content(I18n.t("jobs.document_name"))
+        expect(rendered).to have_no_link(href: %r{/documents/})
+      end
+    end
+  end
+
+  context "when applications are received by email" do
+    context "when no form is attached" do
+      let(:vacancy) do
+        create(:vacancy, enable_job_applications: false, receive_applications: "email", organisations: [organisation])
+      end
+
+      it "does not render the application form row" do
+        expect(rendered).to have_no_content(I18n.t("jobs.application_form"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Trello card URL

- https://teaching-vacancies.sentry.io/issues/7716902999

## Changes in this PR:

We are having a bug when the vacancy review section tries to render the application form but no application form blob is attached to the vacancy.

Guard against it and extend test coverage.

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
