### PR TITLE
Change TRN A-B test to 25%

### DIFF
--- a/config/field_test.yml
+++ b/config/field_test.yml
@@ -4,8 +4,8 @@ experiments:
       - apply
       - trn
     weights:
-      - 95
-      - 5
+      - 75
+      - 25
 
 exclude:
   bots: false


### PR DESCRIPTION
## Trello card URL

https://trello.com/c/Yg6ACKvo/3261-change-trn-a-b-test-percentage-to-25

## Changes in this PR:

Change TRN A-B percentage to 25%