### PR TITLE
Conditionally show warning hint text for terminal ATS statuses

### DIFF
--- a/app/helpers/job_applications_helper.rb
+++ b/app/helpers/job_applications_helper.rb
@@ -40,7 +40,7 @@ module JobApplicationsHelper
     action_required: "orange",
     interviewing: "teal",
     unsuccessful_interview: "red",
-    offered: "purple",
+    offered: "green",
     declined: "grey",
   }.freeze
 

--- a/app/views/publishers/vacancies/job_applications/tag.html.slim
+++ b/app/views/publishers/vacancies/job_applications/tag.html.slim
@@ -21,7 +21,11 @@ h1.govuk-heading-l class="govuk-!-display-inline"
   = f.govuk_radio_buttons_fieldset :status, legend: nil do
     - options = tag_status_options(@form.origin)
     - options[..-2].each do |status|
-      = f.govuk_radio_button :status, status
+      - if %w[unsuccessful unsuccessful_interview].include?(status)
+        = f.govuk_radio_button :status, status
+          p = t(".unsuccessful_hint")
+      - else
+        = f.govuk_radio_button :status, status
     = f.govuk_radio_divider
     = f.govuk_radio_button :status, options.last
 

--- a/config/locales/publishers/job_application_status_form.yml
+++ b/config/locales/publishers/job_application_status_form.yml
@@ -83,7 +83,6 @@ en:
       publishers_job_application_tag_form:
         status_options:
           submitted: Applications that have not been reviewed
-          unsuccessful: Applications that you are not taking forward to interview or that have been withdrawn.
           reviewed: Applications that have been reviewed. Reviewed applications will remain in the 'New' tab until shortlisted or not considering.
           shortlisted: Applications that have been shortlisted.
           interviewing: >-
@@ -120,7 +119,7 @@ en:
           reviewed_html: Reviewed <span class="govuk-tag govuk-tag--purple">Reviewed</span>
           shortlisted_html: Shortlisted <span class="govuk-tag govuk-tag--yellow">Shortlisted</span>
           interviewing_html: Interviewing <span class="govuk-tag govuk-tag--green">Interviewing</span>
-          offered_html: Job offered <span class="govuk-tag govuk-tag--pink">Job offered</span>
+          offered_html: Job offered <span class="govuk-tag govuk-tag--green">Job offered</span>
 
       publishers_job_application_collect_references_form:
         collect_references_options:

--- a/config/locales/publishers/vacancies/job_applications.en.yml
+++ b/config/locales/publishers/vacancies/job_applications.en.yml
@@ -211,6 +211,7 @@ en:
             change_email_success: Email address updated and reference request sent
         tag:
           page_title: Update application status
+          unsuccessful_hint: You cannot undo this action after you select ‘Save and continue’.
           what_application_status:
             one: What application status do you want to assign to this applicant?
             other: What application status do you want to assign to these applicants?

--- a/spec/views/publishers/vacancies/job_applications/index.html.slim_spec.rb
+++ b/spec/views/publishers/vacancies/job_applications/index.html.slim_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe "publishers/vacancies/job_applications/index" do
       it "shows job offered tag" do
         expect(rendered).to have_css(".application-#{status}")
 
-        expect(application_status).to have_css(".govuk-tag--purple", text: "job offered")
+        expect(application_status).to have_css(".govuk-tag--green", text: "job offered")
       end
     end
 

--- a/spec/views/publishers/vacancies/job_applications/tag.html.slim_spec.rb
+++ b/spec/views/publishers/vacancies/job_applications/tag.html.slim_spec.rb
@@ -49,6 +49,14 @@ RSpec.describe "publishers/vacancies/job_applications/tag" do
           expect(rendered).to have_css("#publishers-job-application-tag-form-status-#{status}-field")
         end
       end
+
+      it "only shows the irreversible action hint when not progressing is selected" do
+        expect(tag_page).to have_no_text("Applications that you are not taking forward to interview")
+
+        conditional = tag_page.find("#publishers-job-application-tag-form-status-unsuccessful-conditional")
+        expect(conditional[:class]).to include("govuk-radios__conditional--hidden")
+        expect(conditional).to have_text(I18n.t("publishers.vacancies.job_applications.tag.unsuccessful_hint"))
+      end
     end
 
     context "when job applications have status shortlisted" do
@@ -70,6 +78,20 @@ RSpec.describe "publishers/vacancies/job_applications/tag" do
         it "shows a radio button for status '#{status}'" do
           expect(rendered).to have_css("#publishers-job-application-tag-form-status-#{status}-field")
         end
+      end
+
+      it "conditionally reveals the irreversible action hint for interview unsuccessful" do
+        radio = tag_page.find("#publishers-job-application-tag-form-status-unsuccessful-interview-field")
+        conditional = tag_page.find("#publishers-job-application-tag-form-status-unsuccessful-interview-conditional")
+
+        expect(radio["data-aria-controls"]).to eq(conditional[:id])
+        expect(conditional[:class]).to include("govuk-radios__conditional--hidden")
+        expect(conditional).to have_text(I18n.t("publishers.vacancies.job_applications.tag.unsuccessful_hint"))
+      end
+
+      it "continues to show the job offered hint" do
+        expect(tag_page).to have_text(I18n.t("helpers.hint.publishers_job_application_tag_form.status_options.offered"))
+        expect(tag_page).to have_no_css("#publishers-job-application-tag-form-status-offered-conditional")
       end
     end
   end

--- a/spec/views/publishers/vacancies/job_applications/tag.html.slim_spec.rb
+++ b/spec/views/publishers/vacancies/job_applications/tag.html.slim_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "publishers/vacancies/job_applications/tag" do
       it "only shows the irreversible action hint when not progressing is selected" do
         expect(tag_page).to have_no_text("Applications that you are not taking forward to interview")
 
-        conditional = tag_page.find("#publishers-job-application-tag-form-status-unsuccessful-conditional")
+        conditional = tag_page.find_by_id("publishers-job-application-tag-form-status-unsuccessful-conditional")
         expect(conditional[:class]).to include("govuk-radios__conditional--hidden")
         expect(conditional).to have_text(I18n.t("publishers.vacancies.job_applications.tag.unsuccessful_hint"))
       end
@@ -81,8 +81,8 @@ RSpec.describe "publishers/vacancies/job_applications/tag" do
       end
 
       it "conditionally reveals the irreversible action hint for interview unsuccessful" do
-        radio = tag_page.find("#publishers-job-application-tag-form-status-unsuccessful-interview-field")
-        conditional = tag_page.find("#publishers-job-application-tag-form-status-unsuccessful-interview-conditional")
+        radio = tag_page.find_by_id("publishers-job-application-tag-form-status-unsuccessful-interview-field")
+        conditional = tag_page.find_by_id("publishers-job-application-tag-form-status-unsuccessful-interview-conditional")
 
         expect(radio["data-aria-controls"]).to eq(conditional[:id])
         expect(conditional[:class]).to include("govuk-radios__conditional--hidden")


### PR DESCRIPTION
## Trello card URL
https://trello.com/c/qhukLdgt/3239-confirmation-when-moving-a-job-application-into-rejected-or-not-considering-states

## Changes in this PR:
This PR changes the hint text for options on the ATS which mean that the hiring staff user can no longer edit them if selected. This change removes the existing hint text, replaces it with warning text that only shows when the user selects the radio button. It also changes the job offered tag colour to green.

## Screenshots of UI changes:
<img width="1033" height="727" alt="Screenshot 2026-09-10 at 10 22 15" src="https://github.com/user-attachments/assets/ea3dc3c4-3f13-474b-bcd2-bf30e595eaad" />
<img width="967" height="676" alt="Screenshot 2026-09-10 at 10 22 21" src="https://github.com/user-attachments/assets/9de9ece3-115c-47ab-ae4f-9909cffabeb5" />
<img width="1080" height="625" alt="Screenshot 2026-09-10 at 10 23 29" src="https://github.com/user-attachments/assets/93910924-8a48-4f0c-a0fe-285878835a5e" />
<img width="1102" height="687" alt="Screenshot 2026-09-10 at 10 23 19" src="https://github.com/user-attachments/assets/094e590d-daed-448f-ae0d-f076eee54a7c" />
<img width="1130" height="611" alt="Screenshot 2026-09-10 at 10 25 00" src="https://github.com/user-attachments/assets/1090ca78-e509-4b1b-b154-2c1940215059" />
<img width="1098" height="662" alt="Screenshot 2026-09-10 at 10 24 55" src="https://github.com/user-attachments/assets/1ebbb435-3ffe-48ca-9da9-1e9ac4aa7d1a" />


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
