### PR TITLE
Fix bug on similar jobs vacancy filter query

### DIFF
--- a/app/queries/vacancy_filter_query.rb
+++ b/app/queries/vacancy_filter_query.rb
@@ -30,7 +30,7 @@ class VacancyFilterQuery
     private
 
     def ect_filter_scope(ect_filters)
-      ect_scope = ect_filters.filter_map { |filter|
+      ect_filters.filter_map { |filter|
         # coverage of case statements without an effective 'else' doesn't work properly
         # simplecov:disable
         case filter
@@ -38,10 +38,13 @@ class VacancyFilterQuery
         when "ect_suitable"
           Vacancy.ect_suitable
         when "qts_not_needed"
-          Vacancy.qts_not_needed.merge(Organisation.colleges)
+          # QTS-not-needed only applies to FE colleges. We filter via an id subquery rather than
+          # joining organisations onto the outer scope, so this stays a plain, non-distinct
+          # relation on vacancies (see Search::SimilarJobs, which plucks ids from a query ordered
+          # by ST_Distance - DISTINCT + ORDER BY an expression not in the select list is invalid SQL).
+          Vacancy.where(id: Vacancy.qts_not_needed.joins(:organisations).merge(Organisation.colleges).select(:id))
         end
-      }.reduce { |scope, ect_scope| scope.or(ect_scope) }
-      Vacancy.joins(:organisations).merge(ect_scope).distinct if ect_scope
+      }.reduce { |scope, other| scope.or(other) }
     end
 
     def organisation_type_filters(organisation_types)

--- a/spec/queries/vacancy_filter_query_spec.rb
+++ b/spec/queries/vacancy_filter_query_spec.rb
@@ -171,6 +171,17 @@ RSpec.describe VacancyFilterQuery do
           expect(subject.map(&:job_title)).to match_array([college_non_qts_vacancy, ect_suitable_job].map(&:job_title))
         end
       end
+
+      context "when only ect_suitable is selected" do
+        let(:filters) { { ect_statuses: ["ect_suitable"] } }
+
+        # Regression test: the returned scope must not carry a `.distinct`, otherwise combining it
+        # with an ORDER BY expression not present in the select list (e.g. ST_Distance ordering
+        # used for similar jobs / distance search) raises PG::InvalidColumnReference.
+        it "does not mark the scope as distinct" do
+          expect(subject.distinct_value).to be_falsey
+        end
+      end
     end
 
     context "when organisation_types filter is selected" do

--- a/spec/services/search/similar_jobs_spec.rb
+++ b/spec/services/search/similar_jobs_spec.rb
@@ -15,4 +15,16 @@ RSpec.describe Search::SimilarJobs do
     expect(Search::VacancySearch).to receive(:new).and_call_original
     subject.similar_jobs
   end
+
+  context "when the vacancy is ect_suitable" do
+    # An ect_suitable vacancy makes CriteriaInventor include both `ect_statuses` and `location`,
+    # which makes the similar jobs search sort by distance. Regression test for a bug where the
+    # ect_statuses filter scope carried a `.distinct` that clashed with `pluck(:id)` on a query
+    # ordered by ST_Distance (PG::InvalidColumnReference).
+    let(:vacancy) { create(:vacancy, organisations: [school], ect_status: "ect_suitable") }
+
+    it "does not raise PG::InvalidColumnReference" do
+      expect { subject.similar_jobs }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
## Trello card URL
- https://teaching-vacancies.sentry.io/issues/7724016012

## Changes in this PR:

Fix PG::InvalidColumnReference on vacancy show page from #9168's ect_…filter_scope always wrapping in .joins(:organisations).distinct, which broke Search::SimilarJobs' pluck(:id) on a query ordered by ST_Distance for ect_suitable vacancies

## Screenshots of UI changes:

### Before

### After


## Checklists:

### Data & Schema Changes

If this PR modifies data structures or validations, check the following:

- [ ] Adds/removes model validations
- [ ] Adds/removes database fields
- [ ] Modifies Vacancy enumerables (phases, working patterns, job roles, key stages, etc.)

<details>
<summary>If any of the above options has changed then the author must check/resolve all of the following...</summary>

### Integration Impact

Does this change affect any of these integrations?
- [ ] DfE Analytics platform
- [ ] Legacy imports mappings
- [ ] DWP Find a Job export mappings
- [ ] Publisher ATS API (may require mapping updates or API versioning)

### User Experience & Data Integrity

Could this change impact:
- [ ] Existing subscription alerts (will legacy subscription search filters break?)
- [ ] Legacy vacancy copying (will copied vacancies fail new validations?)
- [ ] In-progress drafts for Vacancies or Job Applications
</details>
