### PR TITLE
Validate infra fix for tv

### DIFF
--- a/.github/workflows/validate-infrastructure.yml
+++ b/.github/workflows/validate-infrastructure.yml
@@ -41,3 +41,5 @@ jobs:
           image-prefix: main-
           confirm-production: YES
           terraform-version-file: ${{ matrix.terraform_version_file }}
+          action_group_email_receivers: ${{ secrets.ACTION_GROUP_EMAIL_RECEIVERS }}
+          action_group_sms_receivers: ${{ secrets.ACTION_GROUP_SMS_RECEIVERS }}


### PR DESCRIPTION
## Changes in this PR:
A recent PR was introduced to import manually created monitoring resources that were created in the Azure portal. The contact groups contained sensitive PII so could not be stored in the code, and were instead passed into the workflow as environment variables. The build-and-deploy workflow was updated to with an additional step to do this, but the validate-infra workflow was not, resulting in it detecting configuration drift. This PR will introduce the same step to validate-infra so the config is aligned with what is deployed in Azure.

## To review:
Review the following workflow outputs:
[teaching-vacancies](https://github.com/DFE-Digital/teaching-vacancies/actions/runs/34595771207/job/103251049044) - Confirm that validate-infra detects no configuration drift when the environment variables are passed in
[register-trainee-teachers](https://github.com/DFE-Digital/register-trainee-teachers/actions/runs/34600567781/job/103266553749) - Confirm that other services will be unaffected by introducing these changes
